### PR TITLE
feat: 目標体重・摂取基準カロリー機能を追加

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -23,4 +23,12 @@ class AppStrings {
   static const String invalidNumber = '有効な数値を入力してください';
   static const String cancel = 'キャンセル';
   static const String delete = '削除';
+  static const String settings = '設定';
+  static const String targetWeight = '目標体重 (kg)';
+  static const String calorieGoal = '摂取基準';
+  static const String save = '保存する';
+  static const String saved = '保存しました';
+  static const String overCalorie = '超過';
+  static const String remainingCalorie = '残り';
+  static const String notSet = '未設定';
 }

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -15,12 +15,16 @@ class DietProvider extends ChangeNotifier {
   );
   List<String> _allDates = [];
   bool _isLoading = true;
+  double? _targetWeight;
 
   DietProvider(this._storage);
 
   DailyRecord get todayRecord => _todayRecord;
   List<String> get allDates => _allDates;
   bool get isLoading => _isLoading;
+  double? get targetWeight => _targetWeight;
+  double? get calorieGoal =>
+      _targetWeight != null ? _targetWeight! * 34 : null;
 
   static String _todayKey() {
     final now = DateTime.now();
@@ -30,11 +34,18 @@ class DietProvider extends ChangeNotifier {
   Future<void> init() async {
     await _storage.init();
     _allDates = _storage.getAllRecordDates();
+    _targetWeight = _storage.loadTargetWeight();
     final today = _storage.loadDailyRecord(_todayKey());
     if (today != null) {
       _todayRecord = today;
     }
     _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> setTargetWeight(double weight) async {
+    _targetWeight = weight;
+    await _storage.saveTargetWeight(weight);
     notifyListeners();
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/food_entry_tile.dart';
 import '../widgets/summary_card.dart';
 import 'add_entry_screen.dart';
 import 'history_screen.dart';
+import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -25,6 +26,13 @@ class _HomeScreenState extends State<HomeScreen> {
         title: Text(
           _currentIndex == 0 ? AppStrings.todayRecord : AppStrings.history,
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: AppStrings.settings,
+            onPressed: () => _openSettings(context),
+          ),
+        ],
       ),
       body: _currentIndex == 0 ? _buildTodayView() : const HistoryScreen(),
       floatingActionButton: _currentIndex == 0
@@ -70,6 +78,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   totalCalories: record.totalCalories,
                   totalProtein: record.totalProtein,
                   entryCount: record.entryCount,
+                  calorieGoal: provider.calorieGoal,
                 ),
                 Expanded(
                   child: record.entries.isEmpty
@@ -109,6 +118,13 @@ class _HomeScreenState extends State<HomeScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const AddEntryScreen()),
+    );
+  }
+
+  void _openSettings(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SettingsScreen()),
     );
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../constants/app_strings.dart';
+import '../providers/diet_provider.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _weightController = TextEditingController();
+  double? _previewGoal;
+
+  @override
+  void initState() {
+    super.initState();
+    final provider = context.read<DietProvider>();
+    if (provider.targetWeight != null) {
+      _weightController.text = provider.targetWeight!.toStringAsFixed(1);
+      _previewGoal = provider.calorieGoal;
+    }
+    _weightController.addListener(_updatePreview);
+  }
+
+  @override
+  void dispose() {
+    _weightController.removeListener(_updatePreview);
+    _weightController.dispose();
+    super.dispose();
+  }
+
+  void _updatePreview() {
+    final value = double.tryParse(_weightController.text.trim());
+    setState(() {
+      _previewGoal = value != null && value > 0 ? value * 34 : null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppStrings.settings),
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextFormField(
+                    controller: _weightController,
+                    decoration: const InputDecoration(
+                      labelText: AppStrings.targetWeight,
+                      prefixIcon: Icon(Icons.monitor_weight),
+                      border: OutlineInputBorder(),
+                      suffixText: 'kg',
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return AppStrings.required;
+                      }
+                      final num = double.tryParse(value.trim());
+                      if (num == null || num <= 0) {
+                        return AppStrings.invalidNumber;
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.local_fire_department,
+                            color: Colors.orange.shade700,
+                          ),
+                          const SizedBox(width: 12),
+                          Text(
+                            '${AppStrings.calorieGoal}: ',
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          Text(
+                            _previewGoal != null
+                                ? '${_previewGoal!.toStringAsFixed(0)} ${AppStrings.kcalUnit}'
+                                : AppStrings.notSet,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: _previewGoal != null
+                                  ? Colors.orange.shade700
+                                  : Colors.grey,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  FilledButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text(AppStrings.save),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _save() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final weight = double.parse(_weightController.text.trim());
+    context.read<DietProvider>().setTargetWeight(weight);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(AppStrings.saved)),
+    );
+
+    Navigator.pop(context);
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -7,6 +7,7 @@ import '../models/daily_record.dart';
 class StorageService {
   static const String _prefix = 'diet_';
   static const String _dateListKey = 'diet_date_list';
+  static const String _targetWeightKey = 'diet_target_weight';
 
   late SharedPreferences _prefs;
 
@@ -36,5 +37,13 @@ class StorageService {
 
   List<String> getAllRecordDates() {
     return _prefs.getStringList(_dateListKey) ?? [];
+  }
+
+  Future<void> saveTargetWeight(double weight) async {
+    await _prefs.setDouble(_targetWeightKey, weight);
+  }
+
+  double? loadTargetWeight() {
+    return _prefs.getDouble(_targetWeightKey);
   }
 }

--- a/lib/widgets/summary_card.dart
+++ b/lib/widgets/summary_card.dart
@@ -6,17 +6,21 @@ class SummaryCard extends StatelessWidget {
   final double totalCalories;
   final double totalProtein;
   final int entryCount;
+  final double? calorieGoal;
 
   const SummaryCard({
     super.key,
     required this.totalCalories,
     required this.totalProtein,
     required this.entryCount,
+    this.calorieGoal,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final hasGoal = calorieGoal != null && calorieGoal! > 0;
+    final isOver = hasGoal && totalCalories > calorieGoal!;
 
     return Card(
       margin: const EdgeInsets.all(16),
@@ -29,12 +33,13 @@ class SummaryCard extends StatelessWidget {
                 Expanded(
                   child: _MetricColumn(
                     icon: Icons.local_fire_department,
-                    iconColor: Colors.orange,
+                    iconColor: isOver ? Colors.red : Colors.orange,
                     label: AppStrings.totalCalories,
-                    value: '${totalCalories.toStringAsFixed(0)} ${AppStrings.kcalUnit}',
+                    value:
+                        '${totalCalories.toStringAsFixed(0)} ${AppStrings.kcalUnit}',
                     valueStyle: theme.textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
-                      color: Colors.orange.shade700,
+                      color: isOver ? Colors.red.shade700 : Colors.orange.shade700,
                     ),
                   ),
                 ),
@@ -48,7 +53,8 @@ class SummaryCard extends StatelessWidget {
                     icon: Icons.fitness_center,
                     iconColor: Colors.blue,
                     label: AppStrings.totalProtein,
-                    value: '${totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
+                    value:
+                        '${totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
                     valueStyle: theme.textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: Colors.blue.shade700,
@@ -57,6 +63,13 @@ class SummaryCard extends StatelessWidget {
                 ),
               ],
             ),
+            if (hasGoal) ...[
+              const SizedBox(height: 16),
+              _CalorieGoalBar(
+                totalCalories: totalCalories,
+                calorieGoal: calorieGoal!,
+              ),
+            ],
             const SizedBox(height: 12),
             Text(
               '${AppStrings.entryCount}: $entryCount ${AppStrings.entryUnit}',
@@ -67,6 +80,58 @@ class SummaryCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _CalorieGoalBar extends StatelessWidget {
+  final double totalCalories;
+  final double calorieGoal;
+
+  const _CalorieGoalBar({
+    required this.totalCalories,
+    required this.calorieGoal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ratio = (totalCalories / calorieGoal).clamp(0.0, 1.5);
+    final isOver = totalCalories > calorieGoal;
+    final diff = (totalCalories - calorieGoal).abs();
+    final barColor = isOver ? Colors.red : Colors.green;
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '${AppStrings.calorieGoal}: ${calorieGoal.toStringAsFixed(0)} ${AppStrings.kcalUnit}',
+              style: theme.textTheme.bodySmall,
+            ),
+            Text(
+              isOver
+                  ? '${AppStrings.overCalorie}: +${diff.toStringAsFixed(0)} ${AppStrings.kcalUnit}'
+                  : '${AppStrings.remainingCalorie}: ${diff.toStringAsFixed(0)} ${AppStrings.kcalUnit}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: isOver ? Colors.red.shade700 : Colors.green.shade700,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: ratio > 1.0 ? 1.0 : ratio,
+            minHeight: 10,
+            backgroundColor: theme.colorScheme.surfaceContainerHighest,
+            valueColor: AlwaysStoppedAnimation<Color>(barColor),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- 目標体重を設定し、摂取基準カロリー（目標体重 × 34 kcal）を算出する機能を追加
- ホーム画面のサマリーカードにプログレスバーで達成状況を可視化（基準以下=緑、超過=赤）
- 設定画面で目標体重入力時に基準カロリーをリアルタイムプレビュー表示

## Test plan
- [x] `flutter analyze` でエラーがないことを確認
- [x] 設定画面で目標体重を入力・保存 → ブラウザリロード後も保持されることを確認
- [x] ホーム画面のSummaryCardに摂取基準カロリーとプログレスバーが表示されることを確認
- [x] 食品を追加して基準を超えた場合、バーが赤色に変わり「超過: +XXX kcal」と表示されることを確認
- [x] 目標体重が未設定の場合、プログレスバーが表示されず従来通りの表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)