### PR TITLE
test/docs: 全画面・ウィジェット・プロバイダーのUT追加 & README拡充

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,172 @@
 # diet_app
+
+毎日の食事（カロリー・タンパク質）を記録するFlutterアプリです。
+目標体重を設定すると摂取基準カロリーが自動計算され、進捗をリアルタイムで確認できます。
+
+---
+
+## 機能
+
+- **食事記録**: 食品名・カロリー・タンパク質を入力して記録
+- **今日のサマリー**: 合計カロリー・タンパク質・記録数を表示
+- **摂取基準カロリー**: 目標体重 × 34 kcal を自動計算し、プログレスバーで進捗表示
+- **履歴**: 過去の日別記録を一覧・詳細確認
+- **永続化**: SharedPreferences によりアプリを終了しても記録を保持
+
+---
+
+## 動作環境
+
+| ツール | バージョン |
+|---|---|
+| Flutter | 3.24.4 (stable) |
+| Dart | 3.5.4 |
+| 対応プラットフォーム | Android / iOS / Web |
+
+---
+
+## セットアップ
+
+### 1. リポジトリのクローン
+
+```cmd
+git clone https://github.com/nanairo7/diet_app.git
+cd diet_app
+```
+
+### 2. 依存パッケージの取得
+
+```cmd
+flutter pub get
+```
+
+---
+
+## 実行
+
+### アプリの起動（Webブラウザ）
+
+```cmd
+flutter run -d chrome
+```
+
+### アプリの起動（接続済みデバイス/エミュレーター）
+
+```cmd
+flutter run
+```
+
+接続されているデバイスを確認する場合:
+
+```cmd
+flutter devices
+```
+
+特定のデバイスを指定して起動する場合:
+
+```cmd
+flutter run -d <device_id>
+```
+
+---
+
+## テスト
+
+### 全テストの実行
+
+```cmd
+flutter test
+```
+
+### 特定ファイルのテストのみ実行
+
+```cmd
+flutter test test/providers/diet_provider_test.dart
+flutter test test/widgets/summary_card_test.dart
+flutter test test/screens/home_screen_test.dart
+```
+
+### テスト結果の詳細を表示
+
+```cmd
+flutter test --reporter expanded
+```
+
+### 期待されるテスト結果
+
+```
+00:04 +99: All tests passed!
+```
+
+---
+
+## テスト構成
+
+| ファイル | テスト数 | 対象 |
+|---|---|---|
+| `test/providers/diet_provider_test.dart` | 22 | 状態管理・ビジネスロジック・永続化 |
+| `test/widgets/summary_card_test.dart` | 13 | サマリーカードの表示・カロリー目標の状態 |
+| `test/widgets/food_entry_tile_test.dart` | 10 | 食事エントリのタイル表示・削除フロー |
+| `test/widgets/daily_record_tile_test.dart` | 8 | 日別記録タイルの表示・タップ操作 |
+| `test/screens/home_screen_test.dart` | 10 | ホーム画面の表示・タブ切り替え・画面遷移 |
+| `test/screens/add_entry_screen_test.dart` | 9 | 食事追加フォームのバリデーション・送信 |
+| `test/screens/settings_screen_test.dart` | 10 | 設定画面の表示・カロリープレビュー・保存 |
+| `test/screens/history_screen_test.dart` | 4 | 履歴画面の空状態・記録あり状態 |
+| `test/screens/day_detail_screen_test.dart` | 6 | 日別詳細画面の表示・集計値 |
+| `test/widget_test.dart` | 1 | アプリ全体のビルド確認 |
+| **合計** | **99** | |
+
+---
+
+## プロジェクト構成
+
+```
+lib/
+├── constants/
+│   ├── app_strings.dart    # UI文字列定数（日本語）
+│   └── app_theme.dart      # Material 3 テーマ設定
+├── models/
+│   ├── daily_record.dart   # 日別記録モデル
+│   └── food_entry.dart     # 食事エントリモデル
+├── providers/
+│   └── diet_provider.dart  # 状態管理（ChangeNotifier）
+├── screens/
+│   ├── home_screen.dart        # ホーム画面（今日の記録・履歴タブ）
+│   ├── add_entry_screen.dart   # 食事追加画面
+│   ├── history_screen.dart     # 履歴一覧画面
+│   ├── day_detail_screen.dart  # 日別詳細画面
+│   └── settings_screen.dart    # 設定画面（目標体重）
+├── services/
+│   └── storage_service.dart    # SharedPreferences による永続化
+├── widgets/
+│   ├── summary_card.dart        # サマリーカード
+│   ├── food_entry_tile.dart     # 食事エントリのリストタイル
+│   └── daily_record_tile.dart   # 日別記録のリストタイル
+└── main.dart                   # アプリエントリーポイント
+
+test/
+├── providers/
+│   └── diet_provider_test.dart
+├── screens/
+│   ├── home_screen_test.dart
+│   ├── add_entry_screen_test.dart
+│   ├── settings_screen_test.dart
+│   ├── history_screen_test.dart
+│   └── day_detail_screen_test.dart
+├── widgets/
+│   ├── summary_card_test.dart
+│   ├── food_entry_tile_test.dart
+│   └── daily_record_tile_test.dart
+└── widget_test.dart
+```
+
+---
+
+## 依存パッケージ
+
+| パッケージ | バージョン | 用途 |
+|---|---|---|
+| [provider](https://pub.dev/packages/provider) | ^6.1.2 | 状態管理（ChangeNotifier） |
+| [shared_preferences](https://pub.dev/packages/shared_preferences) | ^2.3.4 | ローカルデータ永続化 |
+| [intl](https://pub.dev/packages/intl) | ^0.19.0 | 日本語日付フォーマット |
+| [uuid](https://pub.dev/packages/uuid) | ^4.5.1 | 食事エントリのID生成 |


### PR DESCRIPTION
## 概要

各画面・ウィジェット・プロバイダーに対するユニットテスト（UT）を網羅的に追加し、README.mdを実用的なドキュメントに拡充しました。

---

## 変更内容

### 1. ユニットテストの追加（99テスト・全て合格）

#### `test/providers/diet_provider_test.dart` (22テスト)

`DietProvider` はアプリ全体の状態管理を担うコアクラスです。
`SharedPreferences.setMockInitialValues({})` でストレージをモック化してテストします。

| グループ | テスト数 | 主な検証内容 |
|---|---|---|
| 初期化 | 5 | `isLoading`、空の初期状態、`targetWeight`/`calorieGoal`/`allDates` の初期値 |
| `addEntry` | 4 | エントリ追加の反映、複数追加、日付リスト更新、`notifyListeners` の呼び出し |
| `deleteEntry` | 3 | 削除の反映、存在しないIDでもエラーなし、特定エントリのみ削除 |
| `setTargetWeight` | 4 | 目標体重の設定・更新、カロリー目標の自動計算（`weight × 34`）、`notifyListeners` |
| `calorieGoal` | 2 | `null` 時の挙動、計算結果の正確性 |
| `getRecordForDate` | 2 | 今日の記録取得、存在しない日付で `null` |
| 永続化 | 2 | 同じ `StorageService` を使った別インスタンスで目標体重・エントリが復元される |

#### `test/widgets/summary_card_test.dart` (13テスト)

カロリー目標の有無によって表示が動的に変わる部分を重点的にテストしています。

- **カロリー目標なし**: `LinearProgressIndicator` が表示されないことを確認
- **カロリー目標あり**: プログレスバー表示、残りカロリー/超過カロリーのテキスト切り替えを確認
- **注意点**: 目標値テキストと差分テキストに同じ数値が含まれる場合があるため `findsWidgets` を使用

#### `test/widgets/food_entry_tile_test.dart` (10テスト)

`onDelete` の有無で削除ボタンの表示を制御している挙動と、削除ダイアログの各分岐をテストしています。

#### `test/widgets/daily_record_tile_test.dart` (8テスト)

日本語フォーマットの日付表示（`setUpAll` で `initializeDateFormatting('ja')` を呼び出し）と集計値・タップコールバックをテストしています。

#### 各画面のテスト（計39テスト）

| ファイル | テスト数 | 主な検証内容 |
|---|---|---|
| `home_screen_test.dart` | 10 | タブ切り替え・FAB表示制御・画面遷移 |
| `add_entry_screen_test.dart` | 9 | バリデーション・スナックバー表示 |
| `settings_screen_test.dart` | 10 | カロリープレビュー・バリデーション・保存 |
| `history_screen_test.dart` | 4 | 空状態・記録あり状態 |
| `day_detail_screen_test.dart` | 6 | 日付ヘッダー・集計値・削除ボタンなし |

**スナックバーのテストについて**: `Navigator.pop` で画面遷移する前にスナックバーを確認するため、`pumpAndSettle()` ではなく `pump()` を使用しています。

#### `test/widget_test.dart` の修正

元の実装では `DietProvider` が `SharedPreferences` の初期化なしに呼ばれていたためエラーが発生していました。`ChangeNotifierProvider` でモック済みのプロバイダーを提供するよう修正しました。

---

### 2. README.md の拡充

以下の内容を追加しました：

- **機能一覧**: 食事記録・サマリー・摂取基準カロリー・履歴・永続化
- **動作環境**: Flutter / Dart バージョン・対応プラットフォーム
- **セットアップ**: `git clone` → `flutter pub get`
- **実行コマンド**: `flutter run -d chrome` / `flutter run` / `flutter devices`
- **テストコマンド**: `flutter test` / 個別実行 / `--reporter expanded`
- **テスト構成表**: 全10ファイル・99テストの対象一覧
- **プロジェクト構成**: `lib/` と `test/` のディレクトリツリー
- **依存パッケージ表**

---

## テスト実行方法

```cmd
flutter pub get
flutter test
```

## テスト結果

```
00:04 +99: All tests passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)