### PR TITLE
docs: CLAUDE.mdを配置し設計書を整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+## プロジェクト概要
+
+毎日の食事（カロリー・タンパク質）を記録する Flutter アプリ。
+目標体重を設定すると摂取基準カロリー（体重 × 34 kcal）が自動計算され、進捗をリアルタイムで確認できる。
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---|---|
+| フレームワーク | Flutter 3.24.4 / Dart 3.5.4 |
+| 状態管理 | Provider (ChangeNotifier) |
+| 永続化 | SharedPreferences |
+| カレンダー | table_calendar ^3.1.0 |
+| 国際化 | intl ^0.19.0（日本語ロケール） |
+| テスト | flutter_test |
+
+## ディレクトリ構成
+
+```
+lib/
+├── constants/   # 文字列定数・テーマ
+├── models/      # DailyRecord, FoodEntry
+├── providers/   # DietProvider（ChangeNotifier）
+├── screens/     # 5画面
+├── services/    # StorageService（SharedPreferences）
+└── widgets/     # 再利用ウィジェット
+docs/
+└── design/      # 設計書（下記ルール参照）
+test/            # ユニットテスト・ウィジェットテスト
+```
+
+---
+
+## 設計書の管理ルール
+
+- 新機能を実装したら `docs/design/` の該当ドキュメントも更新すること
+- API の変更時は `docs/design/api-design.md` のシーケンス図を更新すること
+- データモデルの変更時は `docs/design/data-model.md` の ER 図を更新すること
+- 画面の追加・変更時は `docs/design/screen-flow.md` の画面フロー図を更新すること
+- アーキテクチャの変更時は `docs/design/architecture.md` のレイヤー図を更新すること
+
+### 設計書一覧
+
+| ファイル | 更新タイミング |
+|---|---|
+| `docs/design/architecture.md` | レイヤー構成・依存関係の変更時 |
+| `docs/design/data-model.md` | モデルのフィールド追加・変更・削除時 |
+| `docs/design/screen-flow.md` | 画面の追加・削除・遷移変更時 |
+| `docs/design/api-design.md` | StorageService やその他サービスの API 変更時 |
+
+---
+
+## 開発ルール
+
+- コミット前に必ず `flutter test` がパスすることを確認する
+- 新しいウィジェット・画面を追加したら対応するテストも追加する
+- テキスト文字列は `lib/constants/app_strings.dart` に定義してハードコードしない
+- 日付キーは `YYYY-MM-DD` 形式（`StorageService` の命名規則に従う）

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ flutter test --reporter expanded
 ### 期待されるテスト結果
 
 ```
-00:04 +99: All tests passed!
+00:04 +102: All tests passed!
 ```
 
 ---
@@ -111,10 +111,10 @@ flutter test --reporter expanded
 | `test/screens/home_screen_test.dart` | 10 | ホーム画面の表示・タブ切り替え・画面遷移 |
 | `test/screens/add_entry_screen_test.dart` | 9 | 食事追加フォームのバリデーション・送信 |
 | `test/screens/settings_screen_test.dart` | 10 | 設定画面の表示・カロリープレビュー・保存 |
-| `test/screens/history_screen_test.dart` | 4 | 履歴画面の空状態・記録あり状態 |
+| `test/screens/history_screen_test.dart` | 7 | 履歴画面のカレンダー表示・日付選択 |
 | `test/screens/day_detail_screen_test.dart` | 6 | 日別詳細画面の表示・集計値 |
 | `test/widget_test.dart` | 1 | アプリ全体のビルド確認 |
-| **合計** | **99** | |
+| **合計** | **102** | |
 
 ---
 
@@ -170,3 +170,4 @@ test/
 | [shared_preferences](https://pub.dev/packages/shared_preferences) | ^2.3.4 | ローカルデータ永続化 |
 | [intl](https://pub.dev/packages/intl) | ^0.19.0 | 日本語日付フォーマット |
 | [uuid](https://pub.dev/packages/uuid) | ^4.5.1 | 食事エントリのID生成 |
+| [table_calendar](https://pub.dev/packages/table_calendar) | ^3.1.0 | 履歴画面のカレンダー表示 |

--- a/docs/design/api-design.md
+++ b/docs/design/api-design.md
@@ -1,0 +1,108 @@
+# API 設計
+
+## DietProvider (`lib/providers/diet_provider.dart`)
+
+### メソッド一覧
+
+| メソッド | 引数 | 戻り値 | 説明 |
+|---|---|---|---|
+| `init()` | なし | `Future<void>` | ストレージを初期化し、全日付・目標体重・今日の記録をロード |
+| `addEntry()` | `name`, `calories`, `protein` | `Future<void>` | UUID を生成して今日の記録にエントリを追加・保存 |
+| `deleteEntry()` | `entryId: String` | `Future<void>` | 今日の記録から指定 ID のエントリを削除・保存 |
+| `setTargetWeight()` | `weight: double` | `Future<void>` | 目標体重を設定・保存。`calorieGoal` が自動更新される |
+| `getRecordForDate()` | `dateKey: String` | `DailyRecord?` | 指定日の記録を返す。今日はメモリ、過去日はストレージから取得 |
+
+### ゲッター一覧
+
+| ゲッター | 型 | 説明 |
+|---|---|---|
+| `todayRecord` | `DailyRecord` | 今日の日付の記録 |
+| `allDates` | `List<String>` | 記録済み全日付キーの一覧（降順） |
+| `isLoading` | `bool` | 初期化完了前は `true` |
+| `targetWeight` | `double?` | 目標体重。未設定時は `null` |
+| `calorieGoal` | `double?` | `targetWeight * 34`。未設定時は `null` |
+
+---
+
+## StorageService (`lib/services/storage_service.dart`)
+
+### メソッド一覧
+
+| メソッド | 引数 | 戻り値 | 副作用 |
+|---|---|---|---|
+| `init()` | なし | `Future<void>` | SharedPreferences インスタンスを初期化 |
+| `saveDailyRecord()` | `record: DailyRecord` | `Future<void>` | `diet_YYYY-MM-DD` キーに JSON 保存。日付リストにも追加（重複なし・降順ソート） |
+| `loadDailyRecord()` | `dateKey: String` | `DailyRecord?` | `diet_YYYY-MM-DD` から JSON を読み込みデシリアライズ。未存在時は `null` |
+| `getAllRecordDates()` | なし | `List<String>` | 降順ソート済み日付キーの一覧を返す |
+| `saveTargetWeight()` | `weight: double` | `Future<void>` | `diet_target_weight` キーに保存 |
+| `loadTargetWeight()` | なし | `double?` | `diet_target_weight` を返す。未設定時は `null` |
+
+---
+
+## シーケンス図
+
+### 食事エントリの追加（addEntry）
+
+```mermaid
+sequenceDiagram
+    participant UI as AddEntryScreen
+    participant DP as DietProvider
+    participant SS as StorageService
+    participant SP as SharedPreferences
+
+    UI->>DP: addEntry(name, calories, protein)
+    DP->>DP: FoodEntry を生成（UUID）
+    DP->>DP: todayRecord.entries に追加
+    DP->>SS: saveDailyRecord(todayRecord)
+    SS->>SP: setString("diet_YYYY-MM-DD", json)
+    SS->>SP: getStringList("diet_date_list")
+    SP-->>SS: dateList
+    SS->>SP: setStringList("diet_date_list", sorted)
+    SS-->>DP: 完了
+    DP->>SS: getAllRecordDates()
+    SS-->>DP: allDates
+    DP->>DP: notifyListeners()
+    DP-->>UI: Consumer が rebuild
+```
+
+### 食事エントリの削除（deleteEntry）
+
+```mermaid
+sequenceDiagram
+    participant UI as FoodEntryTile
+    participant DP as DietProvider
+    participant SS as StorageService
+    participant SP as SharedPreferences
+
+    UI->>UI: 削除確認ダイアログを表示
+    UI->>DP: deleteEntry(entryId)
+    DP->>DP: entries.removeWhere(id == entryId)
+    DP->>SS: saveDailyRecord(todayRecord)
+    SS->>SP: setString("diet_YYYY-MM-DD", json)
+    SS-->>DP: 完了
+    DP->>DP: notifyListeners()
+    DP-->>UI: Consumer が rebuild
+```
+
+### アプリ起動時の初期化（init）
+
+```mermaid
+sequenceDiagram
+    participant App as main.dart
+    participant DP as DietProvider
+    participant SS as StorageService
+    participant SP as SharedPreferences
+
+    App->>DP: DietProvider(storage)..init()
+    DP->>SS: init()
+    SS->>SP: getInstance()
+    SP-->>SS: prefs
+    DP->>SS: getAllRecordDates()
+    SS-->>DP: allDates
+    DP->>SS: loadTargetWeight()
+    SS-->>DP: targetWeight (or null)
+    DP->>SS: loadDailyRecord(todayKey)
+    SS-->>DP: todayRecord (or null)
+    DP->>DP: isLoading = false
+    DP->>DP: notifyListeners()
+```

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,71 @@
+# アーキテクチャ設計
+
+## レイヤー構成
+
+アプリは 4 層のレイヤー構造で設計されています。依存は常に上位レイヤーから下位レイヤーへの一方向です。
+
+```mermaid
+flowchart TD
+    subgraph UI["UI層 (lib/screens/, lib/widgets/)"]
+        HS[HomeScreen]
+        AES[AddEntryScreen]
+        HIS[HistoryScreen]
+        DDS[DayDetailScreen]
+        SS[SettingsScreen]
+        SC[SummaryCard]
+        FET[FoodEntryTile]
+        DRT[DailyRecordTile]
+    end
+
+    subgraph Provider["Provider層 (lib/providers/)"]
+        DP[DietProvider\nChangeNotifier]
+    end
+
+    subgraph Service["Service層 (lib/services/)"]
+        STS[StorageService]
+    end
+
+    subgraph Storage["永続化層"]
+        SP[(SharedPreferences)]
+    end
+
+    UI -->|Consumer / context.read| Provider
+    Provider -->|init / save / load| Service
+    Service -->|get / set / remove| Storage
+```
+
+## 各レイヤーの責務
+
+| レイヤー | ファイル | 責務 |
+|---|---|---|
+| UI 層 | `lib/screens/`, `lib/widgets/` | ユーザーへの表示とインタラクション受付 |
+| Provider 層 | `lib/providers/diet_provider.dart` | アプリ状態の保持・ビジネスロジック・UI への通知 |
+| Service 層 | `lib/services/storage_service.dart` | 永続化の抽象化（SharedPreferences のラッパー） |
+| 永続化層 | SharedPreferences | デバイスへのデータ保存 |
+
+## 状態管理フロー
+
+```mermaid
+sequenceDiagram
+    participant U as ユーザー
+    participant UI as UI層
+    participant DP as DietProvider
+    participant SS as StorageService
+
+    U->>UI: 操作（タップ・入力）
+    UI->>DP: context.read<DietProvider>().method()
+    DP->>SS: save / load
+    SS-->>DP: 結果
+    DP->>DP: notifyListeners()
+    DP-->>UI: Consumer が rebuild
+    UI-->>U: 画面更新
+```
+
+## 技術選定の理由
+
+| 技術 | 採用理由 |
+|---|---|
+| Provider | Flutter 公式推奨の軽量状態管理。シンプルな ChangeNotifier パターンで小規模アプリに適する |
+| SharedPreferences | 構造化 DB 不要なキー・バリュー形式のローカルデータに適する。JSON 文字列として DailyRecord を保存 |
+| table_calendar | Flutter 向けで最も利用実績の多いカレンダーパッケージ。月表示・日付選択・マーカー表示が標準対応 |
+| intl | 日本語ロケールの日付フォーマット（例: `2025年2月`）に使用 |

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -1,0 +1,75 @@
+# データモデル設計
+
+## ER 図
+
+```mermaid
+erDiagram
+    DailyRecord {
+        string dateKey PK "YYYY-MM-DD形式"
+        FoodEntry[] entries "食事エントリの配列"
+    }
+
+    FoodEntry {
+        string id PK "UUID v4"
+        string name "食品名"
+        double calories "カロリー (kcal)"
+        double protein "タンパク質 (g)"
+        DateTime createdAt "作成日時 (ISO 8601)"
+    }
+
+    DailyRecord ||--o{ FoodEntry : "entries"
+```
+
+## モデル詳細
+
+### DailyRecord (`lib/models/daily_record.dart`)
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `dateKey` | `String` | 日付キー。`YYYY-MM-DD` 形式（例: `2025-02-01`） |
+| `entries` | `List<FoodEntry>` | その日の食事エントリ一覧 |
+
+**算出プロパティ（getter）**
+
+| プロパティ | 型 | 算出方法 |
+|---|---|---|
+| `totalCalories` | `double` | `entries` の `calories` 合計 |
+| `totalProtein` | `double` | `entries` の `protein` 合計 |
+| `entryCount` | `int` | `entries.length` |
+
+### FoodEntry (`lib/models/food_entry.dart`)
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `id` | `String` | UUID v4 で生成される一意 ID |
+| `name` | `String` | 食品名（例: `鶏むね肉`） |
+| `calories` | `double` | カロリー（kcal） |
+| `protein` | `double` | タンパク質（g） |
+| `createdAt` | `DateTime` | エントリ作成日時 |
+
+## SharedPreferences ストレージキー
+
+| キー | 型 | 内容 |
+|---|---|---|
+| `diet_YYYY-MM-DD` | `String` | `DailyRecord` の JSON シリアライズ結果 |
+| `diet_date_list` | `List<String>` | 記録済み日付キーの一覧（降順ソート済み） |
+| `diet_target_weight` | `double` | 目標体重（kg）。未設定時は存在しない |
+
+## JSON シリアライズ形式
+
+### DailyRecord
+
+```json
+{
+  "dateKey": "2025-02-01",
+  "entries": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "鶏むね肉",
+      "calories": 150.0,
+      "protein": 30.0,
+      "createdAt": "2025-02-01T12:00:00.000"
+    }
+  ]
+}
+```

--- a/docs/design/screen-flow.md
+++ b/docs/design/screen-flow.md
@@ -1,0 +1,56 @@
+# 画面フロー設計
+
+## 画面遷移図
+
+```mermaid
+flowchart TD
+    Home["🏠 HomeScreen\n（今日の記録タブ）"]
+    History["📅 HistoryScreen\n（履歴タブ）"]
+    Add["➕ AddEntryScreen\n（食事追加）"]
+    Settings["⚙️ SettingsScreen\n（設定）"]
+    Detail["📋 DayDetailScreen\n（日別詳細）"]
+
+    Home -->|"FABタップ"| Add
+    Home -->|"履歴タブタップ"| History
+    Home -->|"設定アイコンタップ"| Settings
+    Add -->|"追加完了 / 戻る"| Home
+    Settings -->|"保存 / 戻る"| Home
+    History -->|"日付または記録タイルタップ"| Detail
+    Detail -->|"戻る"| History
+```
+
+## 画面一覧
+
+### HomeScreen (`lib/screens/home_screen.dart`)
+
+- **役割**: アプリのメインハブ。タブ切り替えで「今日の記録」と「履歴」を表示
+- **今日タブ**: SummaryCard + 食事エントリリスト（削除ボタン付き）
+- **FAB**: AddEntryScreen へ遷移
+- **AppBar**: 設定アイコンで SettingsScreen へ遷移
+
+### AddEntryScreen (`lib/screens/add_entry_screen.dart`)
+
+- **役割**: 食事エントリの新規追加フォーム
+- **入力項目**: 食品名（必須）、カロリー（必須・正数）、タンパク質（必須・正数）
+- **完了後**: SnackBar 表示 → 前画面（HomeScreen）へ戻る
+
+### HistoryScreen (`lib/screens/history_screen.dart`)
+
+- **役割**: 月単位カレンダーで過去の記録を閲覧
+- **カレンダー**: 記録がある日に緑のマーカー表示。矢印ボタンで月を切り替え
+- **日付選択時**: カレンダー下部に選択日の DailyRecordTile を表示
+- **未選択時**: 全記録のリスト表示（降順）
+- **タイルタップ**: DayDetailScreen へ遷移
+
+### DayDetailScreen (`lib/screens/day_detail_screen.dart`)
+
+- **役割**: 特定日の食事記録の読み取り専用詳細ビュー
+- **表示内容**: 日本語フォーマット日付（AppBar）、SummaryCard、食事エントリリスト
+- **削除ボタン**: 表示しない（読み取り専用）
+
+### SettingsScreen (`lib/screens/settings_screen.dart`)
+
+- **役割**: 目標体重の設定
+- **入力項目**: 目標体重（kg）
+- **プレビュー**: 入力値に応じてカロリー目標（体重 × 34 kcal）をリアルタイム表示
+- **保存後**: SnackBar 表示 → 前画面（HomeScreen）へ戻る


### PR DESCRIPTION
## 概要

Claudeへの開発ルールを定義する `CLAUDE.md` を配置し、初期設計書を `docs/design/` に整備しました。
将来の実装変更時に設計書を常に最新状態に保つための仕組みを導入します。

## 変更内容

### 新規ファイル

| ファイル | 内容 |
|---|---|
| `CLAUDE.md` | プロジェクト概要・技術スタック・設計書管理ルール・開発ルール |
| `docs/design/architecture.md` | UI/Provider/Service/Storageの4層レイヤー図（Mermaid） |
| `docs/design/data-model.md` | DailyRecord・FoodEntryのER図とSharedPreferencesキー一覧（Mermaid） |
| `docs/design/screen-flow.md` | 5画面の遷移図（Mermaid） |
| `docs/design/api-design.md` | DietProvider・StorageServiceのAPI仕様とシーケンス図（Mermaid） |

### 更新ファイル

- `README.md`: テスト数を102に更新、`table_calendar` を依存パッケージ表に追記

## CLAUDE.mdの設計書管理ルール

Claudeが実装を行う際に以下のルールを適用します：

- 新機能実装 → `docs/design/` の該当ドキュメントを更新
- API変更 → `docs/design/api-design.md` のシーケンス図を更新
- データモデル変更 → `docs/design/data-model.md` のER図を更新
- 画面追加・変更 → `docs/design/screen-flow.md` の画面フロー図を更新
- コミット前に必ず `flutter test` がパスすることを確認

## テスト

コード変更なし（ドキュメント・設定のみ）のため、既存の102テストがすべて通過します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)