### PR TITLE
feat: 初回起動オンボーディング画面の実装

### DIFF
--- a/docs/design/screen-flow.md
+++ b/docs/design/screen-flow.md
@@ -4,12 +4,17 @@
 
 ```mermaid
 flowchart TD
+    Launch{{"🚀 アプリ起動"}}
+    Onboarding["👋 OnboardingScreen\n（初回起動ガイド）"]
     Home["🏠 HomeScreen\n（今日の記録タブ）"]
     History["📅 HistoryScreen\n（履歴タブ）"]
     Add["➕ AddEntryScreen\n（食事追加）"]
     Settings["⚙️ SettingsScreen\n（設定）"]
     Detail["📋 DayDetailScreen\n（日別詳細）"]
 
+    Launch -->|"初回起動"| Onboarding
+    Launch -->|"2回目以降"| Home
+    Onboarding -->|"はじめる / スキップ"| Home
     Home -->|"FABタップ"| Add
     Home -->|"履歴タブタップ"| History
     Home -->|"設定アイコンタップ"| Settings
@@ -20,6 +25,14 @@ flowchart TD
 ```
 
 ## 画面一覧
+
+### OnboardingScreen (`lib/screens/onboarding_screen.dart`)
+
+- **役割**: 初回起動時のみ表示するウェルカム画面
+- **内容**: アプリ説明 + 主要機能紹介 + 目標体重の初期設定フォーム
+- **「はじめる」**: 目標体重を保存して HomeScreen へ遷移（初回起動フラグを記録）
+- **「スキップ」**: 目標体重を設定せず HomeScreen へ遷移（初回起動フラグを記録）
+- **判定**: `StorageService.isFirstLaunch()` が `true` の場合のみ表示
 
 ### HomeScreen (`lib/screens/home_screen.dart`)
 

--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -34,4 +34,14 @@ class AppStrings {
   static const String noRecordForDay = 'この日の記録はありません';
   static const String calendarView = 'カレンダー';
   static const String listView = 'リスト';
+
+  // Onboarding
+  static const String onboardingTitle = 'カロリー記録へようこそ';
+  static const String onboardingSubtitle = '毎日の食事を記録して\n理想の体型を目指しましょう';
+  static const String onboardingFeature1 = '食事をカロリーとタンパク質で記録';
+  static const String onboardingFeature2 = '目標体重から摂取基準カロリーを自動計算';
+  static const String onboardingFeature3 = 'カレンダーで過去の履歴を確認';
+  static const String onboardingWeightLabel = '目標体重を設定してください';
+  static const String onboardingSkip = 'スキップ';
+  static const String onboardingStart = 'はじめる';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'constants/app_strings.dart';
 import 'constants/app_theme.dart';
 import 'providers/diet_provider.dart';
 import 'screens/home_screen.dart';
+import 'screens/onboarding_screen.dart';
 import 'services/storage_service.dart';
 
 void main() async {
@@ -13,24 +14,28 @@ void main() async {
   await initializeDateFormatting('ja');
 
   final storage = StorageService();
+  await storage.init();
+  final isFirstLaunch = storage.isFirstLaunch();
 
   runApp(
     ChangeNotifierProvider(
       create: (_) => DietProvider(storage)..init(),
-      child: const DietApp(),
+      child: DietApp(isFirstLaunch: isFirstLaunch),
     ),
   );
 }
 
 class DietApp extends StatelessWidget {
-  const DietApp({super.key});
+  const DietApp({super.key, required this.isFirstLaunch});
+
+  final bool isFirstLaunch;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: AppStrings.appTitle,
       theme: AppTheme.lightTheme,
-      home: const HomeScreen(),
+      home: isFirstLaunch ? const OnboardingScreen() : const HomeScreen(),
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -77,4 +77,8 @@ class DietProvider extends ChangeNotifier {
     if (dateKey == _todayKey()) return _todayRecord;
     return _storage.loadDailyRecord(dateKey);
   }
+
+  Future<void> completeOnboarding() async {
+    await _storage.setFirstLaunchDone();
+  }
 }

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../constants/app_strings.dart';
+import '../providers/diet_provider.dart';
+import 'home_screen.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final _weightController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  double? _previewGoal;
+
+  @override
+  void initState() {
+    super.initState();
+    _weightController.addListener(_updatePreview);
+  }
+
+  @override
+  void dispose() {
+    _weightController.removeListener(_updatePreview);
+    _weightController.dispose();
+    super.dispose();
+  }
+
+  void _updatePreview() {
+    final value = double.tryParse(_weightController.text.trim());
+    setState(() {
+      _previewGoal = value != null && value > 0 ? value * 34 : null;
+    });
+  }
+
+  Future<void> _start({bool skip = false}) async {
+    final provider = context.read<DietProvider>();
+    if (!skip) {
+      if (!_formKey.currentState!.validate()) return;
+      final weight = double.parse(_weightController.text.trim());
+      await provider.setTargetWeight(weight);
+    }
+
+    await provider.completeOnboarding();
+
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const HomeScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 32),
+              Icon(
+                Icons.restaurant_menu,
+                size: 80,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                AppStrings.onboardingTitle,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                AppStrings.onboardingSubtitle,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  height: 1.6,
+                ),
+              ),
+              const SizedBox(height: 40),
+              _FeatureTile(
+                icon: Icons.edit_note,
+                text: AppStrings.onboardingFeature1,
+              ),
+              const SizedBox(height: 12),
+              _FeatureTile(
+                icon: Icons.local_fire_department,
+                text: AppStrings.onboardingFeature2,
+              ),
+              const SizedBox(height: 12),
+              _FeatureTile(
+                icon: Icons.calendar_month,
+                text: AppStrings.onboardingFeature3,
+              ),
+              const SizedBox(height: 40),
+              Text(
+                AppStrings.onboardingWeightLabel,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              Form(
+                key: _formKey,
+                child: TextFormField(
+                  controller: _weightController,
+                  decoration: InputDecoration(
+                    labelText: AppStrings.targetWeight,
+                    prefixIcon: const Icon(Icons.monitor_weight),
+                    border: const OutlineInputBorder(),
+                    suffixText: 'kg',
+                    helperText: _previewGoal != null
+                        ? '${AppStrings.calorieGoal}: ${_previewGoal!.toStringAsFixed(0)} ${AppStrings.kcalUnit}'
+                        : null,
+                  ),
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return AppStrings.required;
+                    }
+                    final num = double.tryParse(value.trim());
+                    if (num == null || num <= 0) {
+                      return AppStrings.invalidNumber;
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              const SizedBox(height: 32),
+              FilledButton.icon(
+                onPressed: () => _start(),
+                icon: const Icon(Icons.arrow_forward),
+                label: const Text(AppStrings.onboardingStart),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: () => _start(skip: true),
+                child: const Text(AppStrings.onboardingSkip),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureTile extends StatelessWidget {
+  const _FeatureTile({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Icon(icon, color: theme.colorScheme.primary, size: 28),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Text(text, style: theme.textTheme.bodyLarge),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -8,6 +8,7 @@ class StorageService {
   static const String _prefix = 'diet_';
   static const String _dateListKey = 'diet_date_list';
   static const String _targetWeightKey = 'diet_target_weight';
+  static const String _firstLaunchKey = 'diet_first_launch_done';
 
   late SharedPreferences _prefs;
 
@@ -45,5 +46,13 @@ class StorageService {
 
   double? loadTargetWeight() {
     return _prefs.getDouble(_targetWeightKey);
+  }
+
+  bool isFirstLaunch() {
+    return !(_prefs.getBool(_firstLaunchKey) ?? false);
+  }
+
+  Future<void> setFirstLaunchDone() async {
+    await _prefs.setBool(_firstLaunchKey, true);
   }
 }

--- a/test/screens/onboarding_screen_test.dart
+++ b/test/screens/onboarding_screen_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:diet_app/constants/app_strings.dart';
+import 'package:diet_app/providers/diet_provider.dart';
+import 'package:diet_app/screens/onboarding_screen.dart';
+import 'package:diet_app/services/storage_service.dart';
+
+Future<Widget> _buildTestWidget() async {
+  SharedPreferences.setMockInitialValues({});
+  final storage = StorageService();
+  final provider = DietProvider(storage);
+  await provider.init();
+
+  return ChangeNotifierProvider<DietProvider>.value(
+    value: provider,
+    child: const MaterialApp(home: OnboardingScreen()),
+  );
+}
+
+// 画面の全要素が表示されるよう十分な縦幅を確保
+void _setLargeScreen(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  group('OnboardingScreen - 表示', () {
+    testWidgets('アプリタイトルが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.onboardingTitle), findsOneWidget);
+    });
+
+    testWidgets('サブタイトルが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.onboardingSubtitle), findsOneWidget);
+    });
+
+    testWidgets('3つの機能説明が表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.onboardingFeature1), findsOneWidget);
+      expect(find.text(AppStrings.onboardingFeature2), findsOneWidget);
+      expect(find.text(AppStrings.onboardingFeature3), findsOneWidget);
+    });
+
+    testWidgets('目標体重フィールドが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.targetWeight), findsOneWidget);
+    });
+
+    testWidgets('はじめるボタンが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.onboardingStart), findsOneWidget);
+    });
+
+    testWidgets('スキップボタンが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.onboardingSkip), findsOneWidget);
+    });
+  });
+
+  group('OnboardingScreen - バリデーション', () {
+    testWidgets('空のまま「はじめる」を押すとバリデーションエラーが表示される', (tester) async {
+      _setLargeScreen(tester);
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.tap(find.text(AppStrings.onboardingStart));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.required), findsOneWidget);
+    });
+
+    testWidgets('無効な値で「はじめる」を押すとバリデーションエラーが表示される', (tester) async {
+      _setLargeScreen(tester);
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.enterText(find.byType(TextFormField), '-5');
+      await tester.tap(find.text(AppStrings.onboardingStart));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.invalidNumber), findsOneWidget);
+    });
+  });
+
+  group('OnboardingScreen - カロリープレビュー', () {
+    testWidgets('目標体重を入力するとカロリー目標がプレビュー表示される', (tester) async {
+      _setLargeScreen(tester);
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.enterText(find.byType(TextFormField), '60');
+      await tester.pump();
+      // 60 × 34 = 2040
+      expect(find.textContaining('2040'), findsOneWidget);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -16,7 +16,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<DietProvider>.value(
         value: provider,
-        child: const DietApp(),
+        child: const DietApp(isFirstLaunch: false),
       ),
     );
     await tester.pump();


### PR DESCRIPTION
## 概要

初回起動時のみ表示するオンボーディング画面を実装します。
ユーザーがアプリの使い方を把握し、目標体重を初期設定してから利用開始できるようになります。

## 変更内容

### 新規ファイル
- `lib/screens/onboarding_screen.dart`: オンボーディング画面
- `test/screens/onboarding_screen_test.dart`: テスト（9件）

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/services/storage_service.dart` | `isFirstLaunch()` / `setFirstLaunchDone()` を追加 |
| `lib/providers/diet_provider.dart` | `completeOnboarding()` を追加 |
| `lib/main.dart` | 初回起動判定 → OnboardingScreen/HomeScreen の切り替え |
| `lib/constants/app_strings.dart` | オンボーディング用文字列を追加 |
| `test/widget_test.dart` | `DietApp(isFirstLaunch: false)` に更新 |
| `docs/design/screen-flow.md` | OnboardingScreen を画面遷移図に追加 |

### オンボーディング画面の構成

1. アプリアイコン + タイトル + サブタイトル
2. 3つの機能紹介（食事記録 / カロリー計算 / 履歴カレンダー）
3. 目標体重入力フォーム（カロリー目標をリアルタイムプレビュー）
4. 「はじめる」ボタン（目標体重を保存して開始）
5. 「スキップ」リンク（設定なしで開始）

### 初回起動判定ロジック

```dart
// main.dart
await storage.init();
final isFirstLaunch = storage.isFirstLaunch();
// → isFirstLaunch == true ならオンボーディング画面を表示
```

SharedPreferences キー: `diet_first_launch_done`

## テスト

```
00:05 +111: All tests passed!
```

（オンボーディングテスト 9件を追加、合計 111 テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)