### PR TITLE
feat: ダークモード対応

### DIFF
--- a/lib/constants/app_theme.dart
+++ b/lib/constants/app_theme.dart
@@ -3,6 +3,16 @@ import 'package:flutter/material.dart';
 class AppTheme {
   static ThemeData get lightTheme => ThemeData(
         colorSchemeSeed: Colors.green,
+        brightness: Brightness.light,
+        useMaterial3: true,
+        appBarTheme: const AppBarTheme(
+          centerTitle: true,
+        ),
+      );
+
+  static ThemeData get darkTheme => ThemeData(
+        colorSchemeSeed: Colors.green,
+        brightness: Brightness.dark,
         useMaterial3: true,
         appBarTheme: const AppBarTheme(
           centerTitle: true,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,8 @@ class DietApp extends StatelessWidget {
     return MaterialApp(
       title: AppStrings.appTitle,
       theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.system,
       home: isFirstLaunch ? const OnboardingScreen() : const HomeScreen(),
       debugShowCheckedModeBanner: false,
     );

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -179,7 +179,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
       return Center(
         child: Text(
           AppStrings.noRecordForDay,
-          style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
       );
     }
@@ -198,10 +201,13 @@ class _HistoryScreenState extends State<HistoryScreen> {
     final dates = provider.allDates;
 
     if (dates.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
           AppStrings.noRecords,
-          style: TextStyle(fontSize: 16, color: Colors.grey),
+          style: TextStyle(
+            fontSize: 16,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
       );
     }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -82,13 +82,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 Expanded(
                   child: record.entries.isEmpty
-                      ? const Center(
+                      ? Center(
                           child: Text(
                             AppStrings.noEntries,
                             textAlign: TextAlign.center,
                             style: TextStyle(
                               fontSize: 16,
-                              color: Colors.grey,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
                             ),
                           ),
                         )

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -103,7 +103,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               fontWeight: FontWeight.bold,
                               color: _previewGoal != null
                                   ? Colors.orange.shade700
-                                  : Colors.grey,
+                                  : theme.colorScheme.onSurfaceVariant,
                             ),
                           ),
                         ],

--- a/lib/widgets/summary_card.dart
+++ b/lib/widgets/summary_card.dart
@@ -51,13 +51,13 @@ class SummaryCard extends StatelessWidget {
                 Expanded(
                   child: _MetricColumn(
                     icon: Icons.fitness_center,
-                    iconColor: Colors.blue,
+                    iconColor: theme.colorScheme.tertiary,
                     label: AppStrings.totalProtein,
                     value:
                         '${totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
                     valueStyle: theme.textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
-                      color: Colors.blue.shade700,
+                      color: theme.colorScheme.tertiary,
                     ),
                   ),
                 ),


### PR DESCRIPTION
## 概要

iOS/Android の OS 設定（ライト/ダーク）に自動追従するダークモードを実装します。
Material 3 の `colorSchemeSeed` を活用し、最小限のコード変更で両モードに対応します。

## 変更内容

### テーマ設定（`lib/constants/app_theme.dart`）

| 項目 | 変更前 | 変更後 |
|---|---|---|
| `lightTheme` | 既存 | `brightness: Brightness.light` を明示 |
| `darkTheme` | なし | `colorSchemeSeed: Colors.green` + `Brightness.dark` を追加 |

### アプリ設定（`lib/main.dart`）

```dart
MaterialApp(
  theme: AppTheme.lightTheme,
  darkTheme: AppTheme.darkTheme,   // 追加
  themeMode: ThemeMode.system,      // 追加（OS設定に追従）
)
```

### ハードコードカラーの修正

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `summary_card.dart` | `Colors.blue` / `Colors.blue.shade700` | `theme.colorScheme.tertiary` |
| `history_screen.dart` | `Colors.grey` / `Colors.grey.shade600` | `theme.colorScheme.onSurfaceVariant` |
| `home_screen.dart` | `Colors.grey` | `theme.colorScheme.onSurfaceVariant` |
| `settings_screen.dart` | `Colors.grey`（未設定時） | `theme.colorScheme.onSurfaceVariant` |

### 変更しないカラー（意図的）

- `Colors.orange` / `Colors.red`: カロリー超過の警告色（セマンティックなので維持）
- `Colors.green`: カロリーバーの進捗色（セマンティックなので維持）

## テスト

```
00:06 +111: All tests passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)