### PR TITLE
feat: 食事記録リマインダー通知

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<false/>
+		<key>NSUserNotificationUsageDescription</key>
+		<string>毎日の食事記録を忘れないようにリマインダー通知を送ります。</string>
 	</dict>
 </plist>

--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -35,6 +35,13 @@ class AppStrings {
   static const String calendarView = 'カレンダー';
   static const String listView = 'リスト';
 
+  // Notification
+  static const String notificationSection = '通知設定';
+  static const String notificationEnabled = '食事記録リマインダー';
+  static const String notificationTime = '通知時刻';
+  static const String notificationPermissionDenied =
+      '通知の許可が必要です。設定アプリから通知を有効にしてください。';
+
   // Onboarding
   static const String onboardingTitle = 'カロリー記録へようこそ';
   static const String onboardingSubtitle = '毎日の食事を記録して\n理想の体型を目指しましょう';

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -16,6 +16,9 @@ class DietProvider extends ChangeNotifier {
   List<String> _allDates = [];
   bool _isLoading = true;
   double? _targetWeight;
+  bool _notificationEnabled = false;
+  int _notificationHour = 20;
+  int _notificationMinute = 0;
 
   DietProvider(this._storage);
 
@@ -25,6 +28,9 @@ class DietProvider extends ChangeNotifier {
   double? get targetWeight => _targetWeight;
   double? get calorieGoal =>
       _targetWeight != null ? _targetWeight! * 34 : null;
+  bool get notificationEnabled => _notificationEnabled;
+  int get notificationHour => _notificationHour;
+  int get notificationMinute => _notificationMinute;
 
   static String _todayKey() {
     final now = DateTime.now();
@@ -35,6 +41,9 @@ class DietProvider extends ChangeNotifier {
     await _storage.init();
     _allDates = _storage.getAllRecordDates();
     _targetWeight = _storage.loadTargetWeight();
+    _notificationEnabled = _storage.loadNotificationEnabled();
+    _notificationHour = _storage.loadNotificationHour();
+    _notificationMinute = _storage.loadNotificationMinute();
     final today = _storage.loadDailyRecord(_todayKey());
     if (today != null) {
       _todayRecord = today;
@@ -80,5 +89,21 @@ class DietProvider extends ChangeNotifier {
 
   Future<void> completeOnboarding() async {
     await _storage.setFirstLaunchDone();
+  }
+
+  Future<void> saveNotificationSettings({
+    required bool enabled,
+    required int hour,
+    required int minute,
+  }) async {
+    _notificationEnabled = enabled;
+    _notificationHour = hour;
+    _notificationMinute = minute;
+    await _storage.saveNotificationSettings(
+      enabled: enabled,
+      hour: hour,
+      minute: minute,
+    );
+    notifyListeners();
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../constants/app_strings.dart';
 import '../providers/diet_provider.dart';
+import '../services/notification_service.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -14,7 +15,10 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   final _formKey = GlobalKey<FormState>();
   final _weightController = TextEditingController();
+  final _notificationService = NotificationService();
   double? _previewGoal;
+  bool _notificationEnabled = false;
+  TimeOfDay _notificationTime = const TimeOfDay(hour: 20, minute: 0);
 
   @override
   void initState() {
@@ -25,6 +29,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _previewGoal = provider.calorieGoal;
     }
     _weightController.addListener(_updatePreview);
+    _loadNotificationSettings(provider);
+  }
+
+  void _loadNotificationSettings(DietProvider provider) {
+    setState(() {
+      _notificationEnabled = provider.notificationEnabled;
+      _notificationTime =
+          TimeOfDay(hour: provider.notificationHour, minute: provider.notificationMinute);
+    });
   }
 
   @override
@@ -39,6 +52,55 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() {
       _previewGoal = value != null && value > 0 ? value * 34 : null;
     });
+  }
+
+  Future<void> _toggleNotification(bool enabled) async {
+    if (enabled) {
+      await _notificationService.init();
+      final granted = await _notificationService.requestPermission();
+      if (!mounted) return;
+      if (!granted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(AppStrings.notificationPermissionDenied),
+          ),
+        );
+        return;
+      }
+      await _notificationService.scheduleDaily(
+        hour: _notificationTime.hour,
+        minute: _notificationTime.minute,
+      );
+    } else {
+      await _notificationService.cancel();
+    }
+    if (!mounted) return;
+    await context.read<DietProvider>().saveNotificationSettings(
+          enabled: enabled,
+          hour: _notificationTime.hour,
+          minute: _notificationTime.minute,
+        );
+    setState(() => _notificationEnabled = enabled);
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _notificationTime,
+    );
+    if (picked == null || !mounted) return;
+    setState(() => _notificationTime = picked);
+    if (_notificationEnabled) {
+      await _notificationService.scheduleDaily(
+        hour: picked.hour,
+        minute: picked.minute,
+      );
+      await context.read<DietProvider>().saveNotificationSettings(
+            enabled: true,
+            hour: picked.hour,
+            minute: picked.minute,
+          );
+    }
   }
 
   @override
@@ -117,6 +179,41 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     label: const Text(AppStrings.save),
                     style: FilledButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  Text(
+                    AppStrings.notificationSection,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Card(
+                    child: Column(
+                      children: [
+                        SwitchListTile(
+                          secondary: const Icon(Icons.notifications),
+                          title: const Text(AppStrings.notificationEnabled),
+                          value: _notificationEnabled,
+                          onChanged: _toggleNotification,
+                        ),
+                        if (_notificationEnabled) ...[
+                          const Divider(height: 1),
+                          ListTile(
+                            leading: const Icon(Icons.access_time),
+                            title: const Text(AppStrings.notificationTime),
+                            trailing: Text(
+                              _notificationTime.format(context),
+                              style: theme.textTheme.bodyLarge?.copyWith(
+                                color: theme.colorScheme.primary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            onTap: _pickTime,
+                          ),
+                        ],
+                      ],
                     ),
                   ),
                 ],

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  static const int _reminderId = 1;
+  static const String _channelId = 'diet_reminder';
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    tz.initializeTimeZones();
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    const settings = InitializationSettings(iOS: iosSettings);
+    await _plugin.initialize(settings);
+  }
+
+  Future<bool> requestPermission() async {
+    final ios = _plugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>();
+    if (ios == null) return false;
+    final granted = await ios.requestPermissions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+    return granted ?? false;
+  }
+
+  Future<void> scheduleDaily({required int hour, required int minute}) async {
+    await _plugin.cancel(_reminderId);
+
+    const iosDetails = DarwinNotificationDetails(
+      categoryIdentifier: _channelId,
+    );
+    const details = NotificationDetails(iOS: iosDetails);
+
+    await _plugin.zonedSchedule(
+      _reminderId,
+      '🍽 食事を記録しましょう',
+      '今日の食事をカロリー記録アプリに入力してください',
+      _nextInstanceOfTime(hour, minute),
+      details,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<void> cancel() async {
+    await _plugin.cancel(_reminderId);
+  }
+
+  static tz.TZDateTime _nextInstanceOfTime(int hour, int minute) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled =
+        tz.TZDateTime(tz.local, now.year, now.month, now.day, hour, minute);
+    if (scheduled.isBefore(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -9,6 +9,9 @@ class StorageService {
   static const String _dateListKey = 'diet_date_list';
   static const String _targetWeightKey = 'diet_target_weight';
   static const String _firstLaunchKey = 'diet_first_launch_done';
+  static const String _notificationEnabledKey = 'diet_notification_enabled';
+  static const String _notificationHourKey = 'diet_notification_hour';
+  static const String _notificationMinuteKey = 'diet_notification_minute';
 
   late SharedPreferences _prefs;
 
@@ -54,5 +57,27 @@ class StorageService {
 
   Future<void> setFirstLaunchDone() async {
     await _prefs.setBool(_firstLaunchKey, true);
+  }
+
+  bool loadNotificationEnabled() {
+    return _prefs.getBool(_notificationEnabledKey) ?? false;
+  }
+
+  int loadNotificationHour() {
+    return _prefs.getInt(_notificationHourKey) ?? 20;
+  }
+
+  int loadNotificationMinute() {
+    return _prefs.getInt(_notificationMinuteKey) ?? 0;
+  }
+
+  Future<void> saveNotificationSettings({
+    required bool enabled,
+    required int hour,
+    required int minute,
+  }) async {
+    await _prefs.setBool(_notificationEnabledKey, enabled);
+    await _prefs.setInt(_notificationHourKey, hour);
+    await _prefs.setInt(_notificationMinuteKey, minute);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -150,6 +158,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -461,6 +493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   intl: ^0.19.0
   uuid: ^4.5.1
   table_calendar: ^3.1.0
+  flutter_local_notifications: ^18.0.1
+  timezone: ^0.9.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

毎日指定した時刻に食事記録を促すプッシュ通知を実装します。
設定画面から通知のON/OFFと時刻を変更できます。

## 変更内容

### 新規ファイル
- `lib/services/notification_service.dart`: 通知の初期化・権限リクエスト・スケジュール・キャンセル

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `pubspec.yaml` | `flutter_local_notifications: ^18.0.1` / `timezone: ^0.9.4` を追加 |
| `lib/services/storage_service.dart` | 通知設定の保存/読み込みメソッドを追加 |
| `lib/providers/diet_provider.dart` | 通知設定ゲッター・`saveNotificationSettings()` を追加 |
| `lib/screens/settings_screen.dart` | 通知セクション（スイッチ + 時刻選択）を追加 |
| `lib/constants/app_strings.dart` | 通知設定用文字列を追加 |
| `ios/Runner/Info.plist` | `NSUserNotificationUsageDescription` を追記 |

### 通知フロー

```
設定画面
  └─ 通知スイッチON → iOS権限リクエスト
                    ├─ 許可: 毎日 20:00 (デフォルト) に通知をスケジュール
                    └─ 拒否: スナックバーで設定アプリへの誘導を表示
  └─ 時刻タップ → タイムピッカー → 新しい時刻で再スケジュール
```

### SharedPreferences キー

| キー | 型 | 説明 |
|---|---|---|
| `diet_notification_enabled` | bool | 通知の有効/無効 |
| `diet_notification_hour` | int | 通知時刻（時） |
| `diet_notification_minute` | int | 通知時刻（分） |

## テスト

```
00:06 +111: All tests passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)