### PR TITLE
feat: お気に入り登録機能

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -42,6 +42,14 @@ class AppStrings {
   static const String notificationPermissionDenied =
       '通知の許可が必要です。設定アプリから通知を有効にしてください。';
 
+  // Favorites
+  static const String favorites = 'お気に入り';
+  static const String addToFavorites = 'お気に入りに登録';
+  static const String favoritesEmpty = 'お気に入りはまだありません';
+  static const String addFromFavorites = 'お気に入りから追加';
+  static const String favoriteAdded = 'お気に入りに登録しました';
+  static const String favoriteDeleted = 'お気に入りから削除しました';
+
   // Onboarding
   static const String onboardingTitle = 'カロリー記録へようこそ';
   static const String onboardingSubtitle = '毎日の食事を記録して\n理想の体型を目指しましょう';

--- a/lib/models/favorite_entry.dart
+++ b/lib/models/favorite_entry.dart
@@ -1,0 +1,42 @@
+import 'package:uuid/uuid.dart';
+
+class FavoriteEntry {
+  final String id;
+  final String name;
+  final double calories;
+  final double protein;
+
+  FavoriteEntry({
+    required this.id,
+    required this.name,
+    required this.calories,
+    required this.protein,
+  });
+
+  factory FavoriteEntry.create({
+    required String name,
+    required double calories,
+    required double protein,
+  }) {
+    return FavoriteEntry(
+      id: const Uuid().v4(),
+      name: name,
+      calories: calories,
+      protein: protein,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'calories': calories,
+        'protein': protein,
+      };
+
+  factory FavoriteEntry.fromJson(Map<String, dynamic> json) => FavoriteEntry(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        calories: (json['calories'] as num).toDouble(),
+        protein: (json['protein'] as num).toDouble(),
+      );
+}

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/daily_record.dart';
+import '../models/favorite_entry.dart';
 import '../models/food_entry.dart';
 import '../services/storage_service.dart';
 
@@ -19,6 +20,7 @@ class DietProvider extends ChangeNotifier {
   bool _notificationEnabled = false;
   int _notificationHour = 20;
   int _notificationMinute = 0;
+  List<FavoriteEntry> _favorites = [];
 
   DietProvider(this._storage);
 
@@ -31,6 +33,7 @@ class DietProvider extends ChangeNotifier {
   bool get notificationEnabled => _notificationEnabled;
   int get notificationHour => _notificationHour;
   int get notificationMinute => _notificationMinute;
+  List<FavoriteEntry> get favorites => List.unmodifiable(_favorites);
 
   static String _todayKey() {
     final now = DateTime.now();
@@ -44,6 +47,7 @@ class DietProvider extends ChangeNotifier {
     _notificationEnabled = _storage.loadNotificationEnabled();
     _notificationHour = _storage.loadNotificationHour();
     _notificationMinute = _storage.loadNotificationMinute();
+    _favorites = _storage.loadFavorites();
     final today = _storage.loadDailyRecord(_todayKey());
     if (today != null) {
       _todayRecord = today;
@@ -85,6 +89,27 @@ class DietProvider extends ChangeNotifier {
   DailyRecord? getRecordForDate(String dateKey) {
     if (dateKey == _todayKey()) return _todayRecord;
     return _storage.loadDailyRecord(dateKey);
+  }
+
+  Future<void> addFavorite({
+    required String name,
+    required double calories,
+    required double protein,
+  }) async {
+    final entry = FavoriteEntry.create(
+      name: name,
+      calories: calories,
+      protein: protein,
+    );
+    _favorites = [..._favorites, entry];
+    await _storage.saveFavorites(_favorites);
+    notifyListeners();
+  }
+
+  Future<void> removeFavorite(String id) async {
+    _favorites = _favorites.where((e) => e.id != id).toList();
+    await _storage.saveFavorites(_favorites);
+    notifyListeners();
   }
 
   Future<void> completeOnboarding() async {

--- a/lib/screens/add_entry_screen.dart
+++ b/lib/screens/add_entry_screen.dart
@@ -16,6 +16,7 @@ class _AddEntryScreenState extends State<AddEntryScreen> {
   final _nameController = TextEditingController();
   final _caloriesController = TextEditingController();
   final _proteinController = TextEditingController();
+  bool _addToFavorites = false;
 
   @override
   void dispose() {
@@ -98,7 +99,15 @@ class _AddEntryScreenState extends State<AddEntryScreen> {
                       return null;
                     },
                   ),
-                  const SizedBox(height: 32),
+                  const SizedBox(height: 8),
+                  SwitchListTile(
+                    value: _addToFavorites,
+                    onChanged: (value) => setState(() => _addToFavorites = value),
+                    title: const Text(AppStrings.addToFavorites),
+                    secondary: const Icon(Icons.star_outline),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  const SizedBox(height: 16),
                   FilledButton.icon(
                     onPressed: _submit,
                     icon: const Icon(Icons.add),
@@ -116,21 +125,37 @@ class _AddEntryScreenState extends State<AddEntryScreen> {
     );
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
 
     final name = _nameController.text.trim();
     final calories = double.parse(_caloriesController.text.trim());
     final protein = double.parse(_proteinController.text.trim());
+    final provider = context.read<DietProvider>();
 
-    context.read<DietProvider>().addEntry(
-          name: name,
-          calories: calories,
-          protein: protein,
-        );
+    await provider.addEntry(
+      name: name,
+      calories: calories,
+      protein: protein,
+    );
 
+    if (_addToFavorites) {
+      await provider.addFavorite(
+        name: name,
+        calories: calories,
+        protein: protein,
+      );
+    }
+
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text(AppStrings.added)),
+      SnackBar(
+        content: Text(
+          _addToFavorites
+              ? '${AppStrings.added}・${AppStrings.favoriteAdded}'
+              : AppStrings.added,
+        ),
+      ),
     );
 
     Navigator.pop(context);

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../constants/app_strings.dart';
+import '../providers/diet_provider.dart';
+import '../widgets/favorite_entry_tile.dart';
+
+class FavoritesScreen extends StatelessWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppStrings.favorites),
+      ),
+      body: Consumer<DietProvider>(
+        builder: (context, provider, _) {
+          final favorites = provider.favorites;
+
+          if (favorites.isEmpty) {
+            return const Center(
+              child: Text(AppStrings.favoritesEmpty),
+            );
+          }
+
+          return ListView.separated(
+            itemCount: favorites.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final entry = favorites[index];
+              return FavoriteEntryTile(
+                entry: entry,
+                onAdd: () async {
+                  await provider.addEntry(
+                    name: entry.name,
+                    calories: entry.calories,
+                    protein: entry.protein,
+                  );
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('${entry.name} ${AppStrings.added}')),
+                  );
+                },
+                onDelete: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      content: Text(
+                          '「${entry.name}」を${AppStrings.favorites}から削除しますか？'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          child: const Text(AppStrings.cancel),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          child: const Text(AppStrings.delete),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirmed != true) return;
+                  await provider.removeFavorite(entry.id);
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text(AppStrings.favoriteDeleted)),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../providers/diet_provider.dart';
 import '../widgets/food_entry_tile.dart';
 import '../widgets/summary_card.dart';
 import 'add_entry_screen.dart';
+import 'favorites_screen.dart';
 import 'history_screen.dart';
 import 'settings_screen.dart';
 
@@ -27,6 +28,12 @@ class _HomeScreenState extends State<HomeScreen> {
           _currentIndex == 0 ? AppStrings.todayRecord : AppStrings.history,
         ),
         actions: [
+          if (_currentIndex == 0)
+            IconButton(
+              icon: const Icon(Icons.star_outline),
+              tooltip: AppStrings.favorites,
+              onPressed: () => _openFavorites(context),
+            ),
           IconButton(
             icon: const Icon(Icons.settings),
             tooltip: AppStrings.settings,
@@ -120,6 +127,13 @@ class _HomeScreenState extends State<HomeScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const AddEntryScreen()),
+    );
+  }
+
+  void _openFavorites(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const FavoritesScreen()),
     );
   }
 

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/daily_record.dart';
+import '../models/favorite_entry.dart';
 
 class StorageService {
   static const String _prefix = 'diet_';
@@ -12,6 +13,7 @@ class StorageService {
   static const String _notificationEnabledKey = 'diet_notification_enabled';
   static const String _notificationHourKey = 'diet_notification_hour';
   static const String _notificationMinuteKey = 'diet_notification_minute';
+  static const String _favoritesKey = 'diet_favorites';
 
   late SharedPreferences _prefs;
 
@@ -79,5 +81,17 @@ class StorageService {
     await _prefs.setBool(_notificationEnabledKey, enabled);
     await _prefs.setInt(_notificationHourKey, hour);
     await _prefs.setInt(_notificationMinuteKey, minute);
+  }
+
+  Future<void> saveFavorites(List<FavoriteEntry> favorites) async {
+    final jsonList = favorites.map((e) => jsonEncode(e.toJson())).toList();
+    await _prefs.setStringList(_favoritesKey, jsonList);
+  }
+
+  List<FavoriteEntry> loadFavorites() {
+    final jsonList = _prefs.getStringList(_favoritesKey) ?? [];
+    return jsonList
+        .map((s) => FavoriteEntry.fromJson(jsonDecode(s) as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/lib/widgets/favorite_entry_tile.dart
+++ b/lib/widgets/favorite_entry_tile.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../constants/app_strings.dart';
+import '../models/favorite_entry.dart';
+
+class FavoriteEntryTile extends StatelessWidget {
+  final FavoriteEntry entry;
+  final VoidCallback onAdd;
+  final VoidCallback onDelete;
+
+  const FavoriteEntryTile({
+    super.key,
+    required this.entry,
+    required this.onAdd,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: const Icon(Icons.star, color: Colors.amber),
+      title: Text(entry.name),
+      subtitle: Text(
+        '${entry.calories.toStringAsFixed(0)} ${AppStrings.kcalUnit}  ·  '
+        '${entry.protein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
+        style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
+            tooltip: AppStrings.addFromFavorites,
+            onPressed: onAdd,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: AppStrings.delete,
+            onPressed: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/models/favorite_entry_test.dart
+++ b/test/models/favorite_entry_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:diet_app/models/favorite_entry.dart';
+
+void main() {
+  group('FavoriteEntry - toJson / fromJson', () {
+    test('toJsonが正しいMapを返す', () {
+      final entry = FavoriteEntry(
+        id: 'test-id',
+        name: '鶏むね肉',
+        calories: 150.0,
+        protein: 30.0,
+      );
+      final json = entry.toJson();
+
+      expect(json['id'], 'test-id');
+      expect(json['name'], '鶏むね肉');
+      expect(json['calories'], 150.0);
+      expect(json['protein'], 30.0);
+    });
+
+    test('fromJsonが正しくFavoriteEntryを生成する', () {
+      final json = {
+        'id': 'test-id',
+        'name': '鶏むね肉',
+        'calories': 150.0,
+        'protein': 30.0,
+      };
+      final entry = FavoriteEntry.fromJson(json);
+
+      expect(entry.id, 'test-id');
+      expect(entry.name, '鶏むね肉');
+      expect(entry.calories, 150.0);
+      expect(entry.protein, 30.0);
+    });
+
+    test('toJson → fromJson でラウンドトリップできる', () {
+      final original = FavoriteEntry(
+        id: 'round-trip-id',
+        name: 'サーモン',
+        calories: 200.5,
+        protein: 25.3,
+      );
+      final restored = FavoriteEntry.fromJson(original.toJson());
+
+      expect(restored.id, original.id);
+      expect(restored.name, original.name);
+      expect(restored.calories, original.calories);
+      expect(restored.protein, original.protein);
+    });
+
+    test('FavoriteEntry.createはユニークなIDを生成する', () {
+      final a = FavoriteEntry.create(name: 'A', calories: 100, protein: 10);
+      final b = FavoriteEntry.create(name: 'B', calories: 200, protein: 20);
+      expect(a.id, isNotEmpty);
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('numをdoubleに正しく変換する', () {
+      final json = {
+        'id': 'id',
+        'name': 'テスト',
+        'calories': 100,   // int として渡す
+        'protein': 15,     // int として渡す
+      };
+      final entry = FavoriteEntry.fromJson(json);
+      expect(entry.calories, 100.0);
+      expect(entry.protein, 15.0);
+    });
+  });
+}

--- a/test/providers/diet_provider_test.dart
+++ b/test/providers/diet_provider_test.dart
@@ -144,6 +144,59 @@ void main() {
     });
   });
 
+  group('DietProvider - お気に入り', () {
+    test('初期状態ではお気に入りが空', () {
+      expect(provider.favorites, isEmpty);
+    });
+
+    test('お気に入りを追加できる', () async {
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      expect(provider.favorites.length, 1);
+      expect(provider.favorites.first.name, '鶏むね肉');
+      expect(provider.favorites.first.calories, 150);
+      expect(provider.favorites.first.protein, 30);
+    });
+
+    test('複数のお気に入りを追加できる', () async {
+      await provider.addFavorite(name: '食品A', calories: 100, protein: 10);
+      await provider.addFavorite(name: '食品B', calories: 200, protein: 20);
+      expect(provider.favorites.length, 2);
+    });
+
+    test('お気に入りをIDで削除できる', () async {
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      final id = provider.favorites.first.id;
+      await provider.removeFavorite(id);
+      expect(provider.favorites, isEmpty);
+    });
+
+    test('複数のうち特定のお気に入りだけ削除できる', () async {
+      await provider.addFavorite(name: '食品A', calories: 100, protein: 10);
+      await provider.addFavorite(name: '食品B', calories: 200, protein: 20);
+      final idToDelete = provider.favorites.first.id;
+      await provider.removeFavorite(idToDelete);
+      expect(provider.favorites.length, 1);
+      expect(provider.favorites.first.name, '食品B');
+    });
+
+    test('お気に入り追加後にnotifyListenersが呼ばれる', () async {
+      int notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+      await provider.addFavorite(name: 'テスト', calories: 100, protein: 10);
+      expect(notifyCount, greaterThan(0));
+    });
+
+    test('お気に入りがinit後に復元される', () async {
+      await provider.addFavorite(name: 'ご飯', calories: 250, protein: 4);
+
+      final provider2 = DietProvider(storage);
+      await provider2.init();
+
+      expect(provider2.favorites.length, 1);
+      expect(provider2.favorites.first.name, 'ご飯');
+    });
+  });
+
   group('DietProvider - 永続化', () {
     test('init後に保存済みの目標体重が復元される', () async {
       await provider.setTargetWeight(75.0);

--- a/test/screens/add_entry_screen_test.dart
+++ b/test/screens/add_entry_screen_test.dart
@@ -149,4 +149,47 @@ void main() {
       expect(find.text(AppStrings.added), findsOneWidget);
     });
   });
+
+  group('AddEntryScreen - お気に入りスイッチ', () {
+    testWidgets('お気に入りに登録スイッチが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      expect(find.text(AppStrings.addToFavorites), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsOneWidget);
+    });
+
+    testWidgets('スイッチのデフォルトはOFF', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      final switchWidget =
+          tester.widget<SwitchListTile>(find.byType(SwitchListTile));
+      expect(switchWidget.value, isFalse);
+    });
+
+    testWidgets('スイッチをタップするとONになる', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pump();
+      final switchWidget =
+          tester.widget<SwitchListTile>(find.byType(SwitchListTile));
+      expect(switchWidget.value, isTrue);
+    });
+
+    testWidgets('スイッチONで送信するとお気に入り登録済みスナックバーが表示される',
+        (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+
+      await tester.enterText(
+          find.widgetWithText(TextFormField, AppStrings.foodName), '鶏むね肉');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, AppStrings.calories), '150');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, AppStrings.protein), '30');
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pump();
+      await tester.tap(find.text(AppStrings.addButton));
+      await tester.pump();
+
+      expect(find.text('${AppStrings.added}・${AppStrings.favoriteAdded}'),
+          findsOneWidget);
+    });
+  });
 }

--- a/test/screens/favorites_screen_test.dart
+++ b/test/screens/favorites_screen_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:diet_app/constants/app_strings.dart';
+import 'package:diet_app/providers/diet_provider.dart';
+import 'package:diet_app/screens/favorites_screen.dart';
+import 'package:diet_app/services/storage_service.dart';
+
+Future<Widget> _buildTestWidget(DietProvider provider) async {
+  return ChangeNotifierProvider<DietProvider>.value(
+    value: provider,
+    child: const MaterialApp(home: FavoritesScreen()),
+  );
+}
+
+Future<DietProvider> _makeProvider() async {
+  SharedPreferences.setMockInitialValues({});
+  final storage = StorageService();
+  final provider = DietProvider(storage);
+  await provider.init();
+  return provider;
+}
+
+void main() {
+  group('FavoritesScreen - 空状態', () {
+    testWidgets('お気に入りが空のとき空状態メッセージが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await tester.pumpWidget(await _buildTestWidget(provider));
+
+      expect(find.text(AppStrings.favoritesEmpty), findsOneWidget);
+    });
+
+    testWidgets('画面タイトルが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await tester.pumpWidget(await _buildTestWidget(provider));
+
+      expect(find.text(AppStrings.favorites), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen - リスト表示', () {
+    testWidgets('お気に入りがあるときリストが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉'), findsOneWidget);
+      expect(find.text(AppStrings.favoritesEmpty), findsNothing);
+    });
+
+    testWidgets('複数のお気に入りが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await provider.addFavorite(name: 'ご飯', calories: 250, protein: 4);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉'), findsOneWidget);
+      expect(find.text('ご飯'), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen - 追加操作', () {
+    testWidgets('追加ボタンをタップするとスナックバーが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉 ${AppStrings.added}'), findsOneWidget);
+    });
+
+    testWidgets('追加ボタンをタップしてもお気に入りリストは変わらない', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+
+      expect(provider.favorites.length, 1);
+    });
+  });
+
+  group('FavoritesScreen - 削除操作', () {
+    testWidgets('削除ボタンをタップすると確認ダイアログが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('削除ダイアログでキャンセルするとリストが変わらない', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      await tester.tap(find.text(AppStrings.cancel));
+      await tester.pump();
+
+      expect(provider.favorites.length, 1);
+    });
+
+    testWidgets('削除ダイアログで削除するとリストから消える', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      await tester.tap(find.text(AppStrings.delete));
+      await tester.pump();
+
+      expect(provider.favorites, isEmpty);
+    });
+  });
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -130,4 +130,37 @@ void main() {
       expect(find.textContaining(AppStrings.totalCalories), findsOneWidget);
     });
   });
+
+  group('HomeScreen - お気に入りボタン', () {
+    testWidgets('今日タブで星アイコンが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      expect(find.byIcon(Icons.star_outline), findsOneWidget);
+    });
+
+    testWidgets('星アイコンをタップするとFavoritesScreenに遷移する', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.star_outline));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.favorites), findsOneWidget);
+    });
+
+    testWidgets('履歴タブに切り替えると星アイコンが消える', (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.history));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.star_outline), findsNothing);
+    });
+  });
 }

--- a/test/widgets/favorite_entry_tile_test.dart
+++ b/test/widgets/favorite_entry_tile_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:diet_app/constants/app_strings.dart';
+import 'package:diet_app/models/favorite_entry.dart';
+import 'package:diet_app/widgets/favorite_entry_tile.dart';
+
+FavoriteEntry _makeEntry({
+  String id = 'fav-id',
+  String name = '鶏むね肉',
+  double calories = 150,
+  double protein = 30,
+}) {
+  return FavoriteEntry(id: id, name: name, calories: calories, protein: protein);
+}
+
+Widget _buildTestWidget(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  group('FavoriteEntryTile - 基本表示', () {
+    testWidgets('食品名が表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.text('鶏むね肉'), findsOneWidget);
+    });
+
+    testWidgets('カロリーが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.textContaining('150'), findsOneWidget);
+      expect(find.textContaining(AppStrings.kcalUnit), findsOneWidget);
+    });
+
+    testWidgets('タンパク質が表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.textContaining('30.0'), findsOneWidget);
+      expect(find.textContaining(AppStrings.gramUnit), findsOneWidget);
+    });
+
+    testWidgets('追加アイコンボタンが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    });
+
+    testWidgets('削除アイコンボタンが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    });
+  });
+
+  group('FavoriteEntryTile - コールバック', () {
+    testWidgets('追加ボタンタップでonAddが呼ばれる', (tester) async {
+      bool addCalled = false;
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () => addCalled = true,
+          onDelete: () {},
+        ),
+      ));
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+      expect(addCalled, isTrue);
+    });
+
+    testWidgets('削除ボタンタップでonDeleteが呼ばれる', (tester) async {
+      bool deleteCalled = false;
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () => deleteCalled = true,
+        ),
+      ));
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      expect(deleteCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

食事追加画面にお気に入りスイッチを追加しました。スイッチをONにして追加すると、そのメニューが次回以降のお気に入り選択で使えるように保存されます。

## 変更内容

- **`lib/models/favorite_entry.dart`**（新規）: お気に入りエントリのモデル（id・name・calories・protein）
- **`lib/services/storage_service.dart`**: `saveFavorites` / `loadFavorites` メソッドを追加（`diet_favorites` キーで SharedPreferences に保存）
- **`lib/providers/diet_provider.dart`**: `favorites` getter / `addFavorite` / `removeFavorite` メソッドを追加
- **`lib/screens/add_entry_screen.dart`**: 「お気に入りに登録」SwitchListTile を追加。ONにして送信するとお気に入り保存とスナックバー通知
- **`lib/constants/app_strings.dart`**: お気に入り関連文字列を追加

## テスト

- `test/models/favorite_entry_test.dart`（5件追加）: toJson/fromJson/ラウンドトリップ
- `test/providers/diet_provider_test.dart`（7件追加）: addFavorite・removeFavorite・永続化
- `test/screens/add_entry_screen_test.dart`（4件追加）: スイッチ表示・OFFデフォルト・ON切替・ON送信時スナックバー

**合計 127 テスト全パス**

🤖 Generated with [Claude Code](https://claude.com/claude-code)