### PR TITLE
feat: お気に入りから食事を入力する機能

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../constants/app_strings.dart';
+import '../providers/diet_provider.dart';
+import '../widgets/favorite_entry_tile.dart';
+
+class FavoritesScreen extends StatelessWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppStrings.favorites),
+      ),
+      body: Consumer<DietProvider>(
+        builder: (context, provider, _) {
+          final favorites = provider.favorites;
+
+          if (favorites.isEmpty) {
+            return const Center(
+              child: Text(AppStrings.favoritesEmpty),
+            );
+          }
+
+          return ListView.separated(
+            itemCount: favorites.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final entry = favorites[index];
+              return FavoriteEntryTile(
+                entry: entry,
+                onAdd: () async {
+                  await provider.addEntry(
+                    name: entry.name,
+                    calories: entry.calories,
+                    protein: entry.protein,
+                  );
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('${entry.name} ${AppStrings.added}')),
+                  );
+                },
+                onDelete: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      content: Text(
+                          '「${entry.name}」を${AppStrings.favorites}から削除しますか？'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          child: const Text(AppStrings.cancel),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          child: const Text(AppStrings.delete),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirmed != true) return;
+                  await provider.removeFavorite(entry.id);
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text(AppStrings.favoriteDeleted)),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../providers/diet_provider.dart';
 import '../widgets/food_entry_tile.dart';
 import '../widgets/summary_card.dart';
 import 'add_entry_screen.dart';
+import 'favorites_screen.dart';
 import 'history_screen.dart';
 import 'settings_screen.dart';
 
@@ -27,6 +28,12 @@ class _HomeScreenState extends State<HomeScreen> {
           _currentIndex == 0 ? AppStrings.todayRecord : AppStrings.history,
         ),
         actions: [
+          if (_currentIndex == 0)
+            IconButton(
+              icon: const Icon(Icons.star_outline),
+              tooltip: AppStrings.favorites,
+              onPressed: () => _openFavorites(context),
+            ),
           IconButton(
             icon: const Icon(Icons.settings),
             tooltip: AppStrings.settings,
@@ -120,6 +127,13 @@ class _HomeScreenState extends State<HomeScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const AddEntryScreen()),
+    );
+  }
+
+  void _openFavorites(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const FavoritesScreen()),
     );
   }
 

--- a/lib/widgets/favorite_entry_tile.dart
+++ b/lib/widgets/favorite_entry_tile.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../constants/app_strings.dart';
+import '../models/favorite_entry.dart';
+
+class FavoriteEntryTile extends StatelessWidget {
+  final FavoriteEntry entry;
+  final VoidCallback onAdd;
+  final VoidCallback onDelete;
+
+  const FavoriteEntryTile({
+    super.key,
+    required this.entry,
+    required this.onAdd,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: const Icon(Icons.star, color: Colors.amber),
+      title: Text(entry.name),
+      subtitle: Text(
+        '${entry.calories.toStringAsFixed(0)} ${AppStrings.kcalUnit}  ·  '
+        '${entry.protein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
+        style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
+            tooltip: AppStrings.addFromFavorites,
+            onPressed: onAdd,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: AppStrings.delete,
+            onPressed: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/screens/favorites_screen_test.dart
+++ b/test/screens/favorites_screen_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:diet_app/constants/app_strings.dart';
+import 'package:diet_app/providers/diet_provider.dart';
+import 'package:diet_app/screens/favorites_screen.dart';
+import 'package:diet_app/services/storage_service.dart';
+
+Future<Widget> _buildTestWidget(DietProvider provider) async {
+  return ChangeNotifierProvider<DietProvider>.value(
+    value: provider,
+    child: const MaterialApp(home: FavoritesScreen()),
+  );
+}
+
+Future<DietProvider> _makeProvider() async {
+  SharedPreferences.setMockInitialValues({});
+  final storage = StorageService();
+  final provider = DietProvider(storage);
+  await provider.init();
+  return provider;
+}
+
+void main() {
+  group('FavoritesScreen - 空状態', () {
+    testWidgets('お気に入りが空のとき空状態メッセージが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await tester.pumpWidget(await _buildTestWidget(provider));
+
+      expect(find.text(AppStrings.favoritesEmpty), findsOneWidget);
+    });
+
+    testWidgets('画面タイトルが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await tester.pumpWidget(await _buildTestWidget(provider));
+
+      expect(find.text(AppStrings.favorites), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen - リスト表示', () {
+    testWidgets('お気に入りがあるときリストが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉'), findsOneWidget);
+      expect(find.text(AppStrings.favoritesEmpty), findsNothing);
+    });
+
+    testWidgets('複数のお気に入りが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await provider.addFavorite(name: 'ご飯', calories: 250, protein: 4);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉'), findsOneWidget);
+      expect(find.text('ご飯'), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen - 追加操作', () {
+    testWidgets('追加ボタンをタップするとスナックバーが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+
+      expect(find.text('鶏むね肉 ${AppStrings.added}'), findsOneWidget);
+    });
+
+    testWidgets('追加ボタンをタップしてもお気に入りリストは変わらない', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+
+      expect(provider.favorites.length, 1);
+    });
+  });
+
+  group('FavoritesScreen - 削除操作', () {
+    testWidgets('削除ボタンをタップすると確認ダイアログが表示される', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('削除ダイアログでキャンセルするとリストが変わらない', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      await tester.tap(find.text(AppStrings.cancel));
+      await tester.pump();
+
+      expect(provider.favorites.length, 1);
+    });
+
+    testWidgets('削除ダイアログで削除するとリストから消える', (tester) async {
+      final provider = await _makeProvider();
+      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
+      await tester.pumpWidget(await _buildTestWidget(provider));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      await tester.tap(find.text(AppStrings.delete));
+      await tester.pump();
+
+      expect(provider.favorites, isEmpty);
+    });
+  });
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -130,4 +130,37 @@ void main() {
       expect(find.textContaining(AppStrings.totalCalories), findsOneWidget);
     });
   });
+
+  group('HomeScreen - お気に入りボタン', () {
+    testWidgets('今日タブで星アイコンが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      expect(find.byIcon(Icons.star_outline), findsOneWidget);
+    });
+
+    testWidgets('星アイコンをタップするとFavoritesScreenに遷移する', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.star_outline));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.favorites), findsOneWidget);
+    });
+
+    testWidgets('履歴タブに切り替えると星アイコンが消える', (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.history));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.star_outline), findsNothing);
+    });
+  });
 }

--- a/test/widgets/favorite_entry_tile_test.dart
+++ b/test/widgets/favorite_entry_tile_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:diet_app/constants/app_strings.dart';
+import 'package:diet_app/models/favorite_entry.dart';
+import 'package:diet_app/widgets/favorite_entry_tile.dart';
+
+FavoriteEntry _makeEntry({
+  String id = 'fav-id',
+  String name = '鶏むね肉',
+  double calories = 150,
+  double protein = 30,
+}) {
+  return FavoriteEntry(id: id, name: name, calories: calories, protein: protein);
+}
+
+Widget _buildTestWidget(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  group('FavoriteEntryTile - 基本表示', () {
+    testWidgets('食品名が表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.text('鶏むね肉'), findsOneWidget);
+    });
+
+    testWidgets('カロリーが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.textContaining('150'), findsOneWidget);
+      expect(find.textContaining(AppStrings.kcalUnit), findsOneWidget);
+    });
+
+    testWidgets('タンパク質が表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.textContaining('30.0'), findsOneWidget);
+      expect(find.textContaining(AppStrings.gramUnit), findsOneWidget);
+    });
+
+    testWidgets('追加アイコンボタンが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    });
+
+    testWidgets('削除アイコンボタンが表示される', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () {},
+        ),
+      ));
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    });
+  });
+
+  group('FavoriteEntryTile - コールバック', () {
+    testWidgets('追加ボタンタップでonAddが呼ばれる', (tester) async {
+      bool addCalled = false;
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () => addCalled = true,
+          onDelete: () {},
+        ),
+      ));
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+      expect(addCalled, isTrue);
+    });
+
+    testWidgets('削除ボタンタップでonDeleteが呼ばれる', (tester) async {
+      bool deleteCalled = false;
+      await tester.pumpWidget(_buildTestWidget(
+        FavoriteEntryTile(
+          entry: _makeEntry(),
+          onAdd: () {},
+          onDelete: () => deleteCalled = true,
+        ),
+      ));
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pump();
+      expect(deleteCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

PR #15（お気に入り登録機能）をベースに、登録済みのお気に入りメニューから今日の記録に素早く追加できる機能を実装しました。

## 変更内容

- **`lib/widgets/favorite_entry_tile.dart`**（新規）: お気に入りリスト用タイル。食品名・カロリー・タンパク質を表示し、「追加」「削除」ボタンを持つ
- **`lib/screens/favorites_screen.dart`**（新規）: お気に入り一覧画面。空状態メッセージ・リスト表示・削除確認ダイアログを実装
- **`lib/screens/home_screen.dart`**: 今日タブの AppBar に星アイコンボタン（`Icons.star_outline`）を追加。タップで FavoritesScreen へ遷移。履歴タブでは非表示

## 操作フロー

```
HomeScreen（今日タブ）
  ↓ 星アイコンをタップ
FavoritesScreen（お気に入り一覧）
  ├─ 「+」ボタン → 今日の記録に追加 → スナックバー（画面は閉じない）
  └─ 🗑 ボタン → 確認ダイアログ → お気に入りから削除
```

## テスト

- `test/screens/favorites_screen_test.dart`（8件追加）: 空状態・リスト表示・追加・削除操作
- `test/widgets/favorite_entry_tile_test.dart`（7件追加）: 表示・コールバック
- `test/screens/home_screen_test.dart`（3件追加）: 星アイコン表示・遷移・履歴タブで非表示

**合計 146 テスト全パス**

🤖 Generated with [Claude Code](https://claude.com/claude-code)