### PR TITLE
feat: 履歴から食事追加・お気に入り画面改善

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -46,6 +46,7 @@ class AppStrings {
       '通知の許可が必要です。設定アプリから通知を有効にしてください。';
 
   // Favorites
+  static const String todayIntake = '今日の摂取量';
   static const String favorites = 'お気に入り';
   static const String addToFavorites = 'お気に入りに登録';
   static const String favoritesEmpty = 'お気に入りはまだありません';

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -80,6 +80,33 @@ class DietProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> addEntryForDate({
+    required String dateKey,
+    required String name,
+    required double calories,
+    required double protein,
+  }) async {
+    final entry = FoodEntry(
+      id: _uuid.v4(),
+      name: name,
+      calories: calories,
+      protein: protein,
+      createdAt: DateTime.now(),
+    );
+
+    if (dateKey == _todayKey()) {
+      _todayRecord.entries.add(entry);
+      await _storage.saveDailyRecord(_todayRecord);
+    } else {
+      final record = _storage.loadDailyRecord(dateKey) ??
+          DailyRecord(dateKey: dateKey, entries: []);
+      record.entries.add(entry);
+      await _storage.saveDailyRecord(record);
+    }
+    _allDates = _storage.getAllRecordDates();
+    notifyListeners();
+  }
+
   Future<void> deleteEntry(String entryId) async {
     _todayRecord.entries.removeWhere((e) => e.id == entryId);
     await _storage.saveDailyRecord(_todayRecord);

--- a/lib/screens/day_detail_screen.dart
+++ b/lib/screens/day_detail_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
+import '../constants/app_strings.dart';
 import '../models/daily_record.dart';
+import '../providers/diet_provider.dart';
 import '../widgets/food_entry_tile.dart';
 import '../widgets/summary_card.dart';
 
@@ -14,34 +17,193 @@ class DayDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final date = DateTime.parse(record.dateKey);
     final formattedDate = DateFormat.yMMMEd('ja').format(date);
+    final dateKey = record.dateKey;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(formattedDate),
       ),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600),
-          child: Column(
-            children: [
-              SummaryCard(
-                totalCalories: record.totalCalories,
-                totalProtein: record.totalProtein,
-                entryCount: record.entryCount,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openAddEntrySheet(context, dateKey),
+        tooltip: AppStrings.addFood,
+        child: const Icon(Icons.add),
+      ),
+      body: Consumer<DietProvider>(
+        builder: (context, provider, _) {
+          // 最新データを provider から取得（追加後に即時反映）
+          final liveRecord = provider.getRecordForDate(dateKey) ?? record;
+
+          return Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: Column(
+                children: [
+                  SummaryCard(
+                    totalCalories: liveRecord.totalCalories,
+                    totalProtein: liveRecord.totalProtein,
+                    entryCount: liveRecord.entryCount,
+                  ),
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: liveRecord.entryCount,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        return FoodEntryTile(
+                            entry: liveRecord.entries[index]);
+                      },
+                    ),
+                  ),
+                ],
               ),
-              Expanded(
-                child: ListView.separated(
-                  itemCount: record.entryCount,
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemBuilder: (context, index) {
-                    return FoodEntryTile(entry: record.entries[index]);
-                  },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _openAddEntrySheet(BuildContext context, String dateKey) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => _AddEntryBottomSheet(dateKey: dateKey),
+    );
+  }
+}
+
+// ─── 食事追加ボトムシート ───────────────────────────────────────────
+
+class _AddEntryBottomSheet extends StatefulWidget {
+  final String dateKey;
+
+  const _AddEntryBottomSheet({required this.dateKey});
+
+  @override
+  State<_AddEntryBottomSheet> createState() => _AddEntryBottomSheetState();
+}
+
+class _AddEntryBottomSheetState extends State<_AddEntryBottomSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _caloriesController = TextEditingController();
+  final _proteinController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _caloriesController.dispose();
+    _proteinController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              AppStrings.addFood,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: AppStrings.foodName,
+                prefixIcon: Icon(Icons.restaurant),
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              textInputAction: TextInputAction.next,
+              autofocus: true,
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? AppStrings.required : null,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    controller: _caloriesController,
+                    decoration: const InputDecoration(
+                      labelText: AppStrings.calories,
+                      prefixIcon: Icon(Icons.local_fire_department),
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    textInputAction: TextInputAction.next,
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) {
+                        return AppStrings.required;
+                      }
+                      final n = double.tryParse(v.trim());
+                      if (n == null || n < 0) return AppStrings.invalidNumber;
+                      return null;
+                    },
+                  ),
                 ),
-              ),
-            ],
-          ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextFormField(
+                    controller: _proteinController,
+                    decoration: const InputDecoration(
+                      labelText: AppStrings.protein,
+                      prefixIcon: Icon(Icons.fitness_center),
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) => _submit(),
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) {
+                        return AppStrings.required;
+                      }
+                      final n = double.tryParse(v.trim());
+                      if (n == null || n < 0) return AppStrings.invalidNumber;
+                      return null;
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _submit,
+              child: const Text(AppStrings.addButton),
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final provider = context.read<DietProvider>();
+    await provider.addEntryForDate(
+      dateKey: widget.dateKey,
+      name: _nameController.text.trim(),
+      calories: double.parse(_caloriesController.text.trim()),
+      protein: double.parse(_proteinController.text.trim()),
+    );
+
+    if (!mounted) return;
+    Navigator.pop(context);
   }
 }

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -17,60 +17,119 @@ class FavoritesScreen extends StatelessWidget {
       body: Consumer<DietProvider>(
         builder: (context, provider, _) {
           final favorites = provider.favorites;
+          final record = provider.todayRecord;
 
-          if (favorites.isEmpty) {
-            return const Center(
-              child: Text(AppStrings.favoritesEmpty),
-            );
-          }
-
-          return ListView.separated(
-            itemCount: favorites.length,
-            separatorBuilder: (_, __) => const Divider(height: 1),
-            itemBuilder: (context, index) {
-              final entry = favorites[index];
-              return FavoriteEntryTile(
-                entry: entry,
-                onAdd: () async {
-                  await provider.addEntry(
-                    name: entry.name,
-                    calories: entry.calories,
-                    protein: entry.protein,
-                  );
-                  if (!context.mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('${entry.name} ${AppStrings.added}')),
-                  );
-                },
-                onDelete: () async {
-                  final confirmed = await showDialog<bool>(
-                    context: context,
-                    builder: (ctx) => AlertDialog(
-                      content: Text(
-                          '「${entry.name}」を${AppStrings.favorites}から削除しますか？'),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(ctx, false),
-                          child: const Text(AppStrings.cancel),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(ctx, true),
-                          child: const Text(AppStrings.delete),
-                        ),
-                      ],
-                    ),
-                  );
-                  if (confirmed != true) return;
-                  await provider.removeFavorite(entry.id);
-                  if (!context.mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text(AppStrings.favoriteDeleted)),
-                  );
-                },
-              );
-            },
+          return Column(
+            children: [
+              _TodayIntakeSummary(
+                totalCalories: record.totalCalories,
+                totalProtein: record.totalProtein,
+                calorieGoal: provider.calorieGoal,
+              ),
+              const Divider(height: 1),
+              Expanded(
+                child: favorites.isEmpty
+                    ? const Center(child: Text(AppStrings.favoritesEmpty))
+                    : ListView.separated(
+                        itemCount: favorites.length,
+                        separatorBuilder: (_, __) => const Divider(height: 1),
+                        itemBuilder: (context, index) {
+                          final entry = favorites[index];
+                          return FavoriteEntryTile(
+                            entry: entry,
+                            onAdd: () async {
+                              await provider.addEntry(
+                                name: entry.name,
+                                calories: entry.calories,
+                                protein: entry.protein,
+                              );
+                            },
+                            onDelete: () async {
+                              final confirmed = await showDialog<bool>(
+                                context: context,
+                                builder: (ctx) => AlertDialog(
+                                  content: Text(
+                                      '「${entry.name}」を${AppStrings.favorites}から削除しますか？'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () =>
+                                          Navigator.pop(ctx, false),
+                                      child: const Text(AppStrings.cancel),
+                                    ),
+                                    TextButton(
+                                      onPressed: () =>
+                                          Navigator.pop(ctx, true),
+                                      child: const Text(AppStrings.delete),
+                                    ),
+                                  ],
+                                ),
+                              );
+                              if (confirmed != true) return;
+                              await provider.removeFavorite(entry.id);
+                            },
+                          );
+                        },
+                      ),
+              ),
+            ],
           );
         },
+      ),
+    );
+  }
+}
+
+class _TodayIntakeSummary extends StatelessWidget {
+  final double totalCalories;
+  final double totalProtein;
+  final double? calorieGoal;
+
+  const _TodayIntakeSummary({
+    required this.totalCalories,
+    required this.totalProtein,
+    this.calorieGoal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final calorieText = calorieGoal != null
+        ? '${totalCalories.toStringAsFixed(0)} / ${calorieGoal!.toStringAsFixed(0)} ${AppStrings.kcalUnit}'
+        : '${totalCalories.toStringAsFixed(0)} ${AppStrings.kcalUnit}';
+
+    return Container(
+      width: double.infinity,
+      color: theme.colorScheme.surfaceContainerLow,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          Text(
+            AppStrings.todayIntake,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Icon(Icons.local_fire_department,
+              size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 4),
+          Text(
+            calorieText,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Icon(Icons.fitness_center,
+              size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 4),
+          Text(
+            '${totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -27,6 +27,7 @@ class _AddEntrySheetState extends State<_AddEntrySheet> {
   final _nameController = TextEditingController();
   final _caloriesController = TextEditingController();
   final _proteinController = TextEditingController();
+  bool _addToFavorites = false;
 
   @override
   void dispose() {
@@ -121,9 +122,25 @@ class _AddEntrySheetState extends State<_AddEntrySheet> {
               ],
             ),
             const SizedBox(height: 16),
-            FilledButton(
-              onPressed: _submit,
-              child: const Text(AppStrings.addButton),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton(
+                    onPressed: _submit,
+                    child: const Text(AppStrings.addButton),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton.outlined(
+                  onPressed: () =>
+                      setState(() => _addToFavorites = !_addToFavorites),
+                  icon: Icon(
+                    _addToFavorites ? Icons.star : Icons.star_outline,
+                    color: _addToFavorites ? Colors.amber : null,
+                  ),
+                  tooltip: AppStrings.addToFavorites,
+                ),
+              ],
             ),
           ],
         ),
@@ -134,13 +151,26 @@ class _AddEntrySheetState extends State<_AddEntrySheet> {
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
 
+    final name = _nameController.text.trim();
+    final calories = double.parse(_caloriesController.text.trim());
+    final protein = double.parse(_proteinController.text.trim());
+    final savedToFavorites = _addToFavorites;
     final provider = context.read<DietProvider>();
+
     await provider.addEntryForDate(
       dateKey: widget.dateKey,
-      name: _nameController.text.trim(),
-      calories: double.parse(_caloriesController.text.trim()),
-      protein: double.parse(_proteinController.text.trim()),
+      name: name,
+      calories: calories,
+      protein: protein,
     );
+
+    if (savedToFavorites) {
+      await provider.addFavorite(
+        name: name,
+        calories: calories,
+        protein: protein,
+      );
+    }
 
     if (!mounted) return;
     Navigator.pop(context);

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -316,7 +316,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
     return Column(
       children: [
         Expanded(
-          child: record == null
+          child: (record == null || record.entries.isEmpty)
               ? Center(
                   child: Text(
                     AppStrings.noRecordForDay,

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -9,6 +9,142 @@ import '../providers/diet_provider.dart';
 import '../widgets/daily_record_tile.dart';
 import 'day_detail_screen.dart';
 
+// ─── 食事追加ボトムシート ───────────────────────────────────────────
+
+class _AddEntrySheet extends StatefulWidget {
+  final String dateKey;
+
+  const _AddEntrySheet({required this.dateKey});
+
+  @override
+  State<_AddEntrySheet> createState() => _AddEntrySheetState();
+}
+
+class _AddEntrySheetState extends State<_AddEntrySheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _caloriesController = TextEditingController();
+  final _proteinController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _caloriesController.dispose();
+    _proteinController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              AppStrings.addFood,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: AppStrings.foodName,
+                prefixIcon: Icon(Icons.restaurant),
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              textInputAction: TextInputAction.next,
+              autofocus: true,
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? AppStrings.required : null,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    controller: _caloriesController,
+                    decoration: const InputDecoration(
+                      labelText: AppStrings.calories,
+                      prefixIcon: Icon(Icons.local_fire_department),
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    textInputAction: TextInputAction.next,
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) {
+                        return AppStrings.required;
+                      }
+                      final n = double.tryParse(v.trim());
+                      if (n == null || n < 0) return AppStrings.invalidNumber;
+                      return null;
+                    },
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextFormField(
+                    controller: _proteinController,
+                    decoration: const InputDecoration(
+                      labelText: AppStrings.protein,
+                      prefixIcon: Icon(Icons.fitness_center),
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) => _submit(),
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) {
+                        return AppStrings.required;
+                      }
+                      final n = double.tryParse(v.trim());
+                      if (n == null || n < 0) return AppStrings.invalidNumber;
+                      return null;
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _submit,
+              child: const Text(AppStrings.addButton),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final provider = context.read<DietProvider>();
+    await provider.addEntryForDate(
+      dateKey: widget.dateKey,
+      name: _nameController.text.trim(),
+      calories: double.parse(_caloriesController.text.trim()),
+      protein: double.parse(_proteinController.text.trim()),
+    );
+
+    if (!mounted) return;
+    Navigator.pop(context);
+  }
+}
+
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});
 
@@ -175,25 +311,48 @@ class _HistoryScreenState extends State<HistoryScreen> {
     final dateKey = _toDateKey(_selectedDay!);
     final record = provider.getRecordForDate(dateKey);
 
-    if (record == null) {
-      return Center(
-        child: Text(
-          AppStrings.noRecordForDay,
-          style: TextStyle(
-            fontSize: 16,
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
+    return Column(
+      children: [
+        Expanded(
+          child: record == null
+              ? Center(
+                  child: Text(
+                    AppStrings.noRecordForDay,
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              : ListView(
+                  children: [
+                    DailyRecordTile(
+                      record: record,
+                      onTap: () => _openDayDetail(context, record),
+                    ),
+                  ],
+                ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton.tonal(
+              onPressed: () => _openAddEntrySheet(context, dateKey),
+              child: const Text(AppStrings.addFood),
+            ),
           ),
         ),
-      );
-    }
-
-    return ListView(
-      children: [
-        DailyRecordTile(
-          record: record,
-          onTap: () => _openDayDetail(context, record),
-        ),
       ],
+    );
+  }
+
+  void _openAddEntrySheet(BuildContext context, String dateKey) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => _AddEntrySheet(dateKey: dateKey),
     );
   }
 

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -7,6 +7,8 @@ import '../constants/app_strings.dart';
 import '../models/daily_record.dart';
 import '../providers/diet_provider.dart';
 import '../widgets/daily_record_tile.dart';
+import '../widgets/food_entry_tile.dart';
+import '../widgets/summary_card.dart';
 import 'day_detail_screen.dart';
 
 // ─── 食事追加ボトムシート ───────────────────────────────────────────
@@ -324,13 +326,21 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     ),
                   ),
                 )
-              : ListView(
-                  children: [
-                    DailyRecordTile(
-                      record: record,
-                      onTap: () => _openDayDetail(context, record),
-                    ),
-                  ],
+              : ListView.separated(
+                  itemCount: record.entries.length + 1,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    if (index == 0) {
+                      return SummaryCard(
+                        totalCalories: record.totalCalories,
+                        totalProtein: record.totalProtein,
+                        entryCount: record.entryCount,
+                      );
+                    }
+                    return FoodEntryTile(
+                      entry: record.entries[index - 1],
+                    );
+                  },
                 ),
         ),
         Padding(

--- a/lib/widgets/favorite_entry_tile.dart
+++ b/lib/widgets/favorite_entry_tile.dart
@@ -26,21 +26,12 @@ class FavoriteEntryTile extends StatelessWidget {
         '${entry.protein.toStringAsFixed(1)} ${AppStrings.gramUnit}',
         style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
       ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.add_circle_outline),
-            tooltip: AppStrings.addFromFavorites,
-            onPressed: onAdd,
-          ),
-          IconButton(
-            icon: const Icon(Icons.delete_outline),
-            tooltip: AppStrings.delete,
-            onPressed: onDelete,
-          ),
-        ],
+      trailing: IconButton(
+        icon: const Icon(Icons.delete_outline),
+        tooltip: AppStrings.delete,
+        onPressed: onDelete,
       ),
+      onTap: onAdd,
     );
   }
 }

--- a/test/providers/diet_provider_test.dart
+++ b/test/providers/diet_provider_test.dart
@@ -197,6 +197,58 @@ void main() {
     });
   });
 
+  group('DietProvider - addEntryForDate', () {
+    test('過去の日付にエントリを追加できる', () async {
+      await provider.addEntryForDate(
+        dateKey: '2024-01-01',
+        name: '朝食',
+        calories: 300,
+        protein: 15,
+      );
+      final record = provider.getRecordForDate('2024-01-01');
+      expect(record, isNotNull);
+      expect(record!.entries.length, 1);
+      expect(record.entries.first.name, '朝食');
+    });
+
+    test('過去日付への追加でallDatesが更新される', () async {
+      await provider.addEntryForDate(
+        dateKey: '2024-01-01',
+        name: '昼食',
+        calories: 500,
+        protein: 20,
+      );
+      expect(provider.allDates, contains('2024-01-01'));
+    });
+
+    test('今日の日付でaddEntryForDateを呼ぶとtodayRecordに反映される', () async {
+      final todayKey = provider.todayRecord.dateKey;
+      await provider.addEntryForDate(
+        dateKey: todayKey,
+        name: '夕食',
+        calories: 700,
+        protein: 30,
+      );
+      expect(provider.todayRecord.entries.length, 1);
+      expect(provider.todayRecord.entries.first.name, '夕食');
+    });
+
+    test('記録のない過去日付に追加すると新規DailyRecordが作成される', () async {
+      expect(provider.getRecordForDate('2023-06-15'), isNull);
+
+      await provider.addEntryForDate(
+        dateKey: '2023-06-15',
+        name: 'テスト食品',
+        calories: 100,
+        protein: 5,
+      );
+
+      final record = provider.getRecordForDate('2023-06-15');
+      expect(record, isNotNull);
+      expect(record!.dateKey, '2023-06-15');
+    });
+  });
+
   group('DietProvider - 永続化', () {
     test('init後に保存済みの目標体重が復元される', () async {
       await provider.setTargetWeight(75.0);

--- a/test/screens/day_detail_screen_test.dart
+++ b/test/screens/day_detail_screen_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:diet_app/constants/app_strings.dart';
 import 'package:diet_app/models/daily_record.dart';
 import 'package:diet_app/models/food_entry.dart';
+import 'package:diet_app/providers/diet_provider.dart';
 import 'package:diet_app/screens/day_detail_screen.dart';
+import 'package:diet_app/services/storage_service.dart';
 
 DailyRecord _makeRecord({
   String dateKey = '2024-01-15',
@@ -32,8 +36,18 @@ FoodEntry _makeEntry({
   );
 }
 
-Widget _buildTestWidget(DailyRecord record) {
-  return MaterialApp(home: DayDetailScreen(record: record));
+Future<Widget> _buildTestWidget(DailyRecord record) async {
+  SharedPreferences.setMockInitialValues({});
+  final storage = StorageService();
+  final provider = DietProvider(storage);
+  await provider.init();
+
+  return MaterialApp(
+    home: ChangeNotifierProvider<DietProvider>.value(
+      value: provider,
+      child: DayDetailScreen(record: record),
+    ),
+  );
 }
 
 void main() {
@@ -43,14 +57,14 @@ void main() {
 
   group('DayDetailScreen - 表示', () {
     testWidgets('日付がアプリバーに表示される', (tester) async {
-      await tester.pumpWidget(_buildTestWidget(_makeRecord(dateKey: '2024-01-15')));
+      await tester.pumpWidget(await _buildTestWidget(_makeRecord(dateKey: '2024-01-15')));
 
       // 日本語フォーマットで1月が含まれる
       expect(find.textContaining('1月'), findsOneWidget);
     });
 
     testWidgets('SummaryCardが表示される', (tester) async {
-      await tester.pumpWidget(_buildTestWidget(_makeRecord()));
+      await tester.pumpWidget(await _buildTestWidget(_makeRecord()));
 
       expect(find.textContaining(AppStrings.totalCalories), findsOneWidget);
       expect(find.textContaining(AppStrings.totalProtein), findsOneWidget);
@@ -60,7 +74,7 @@ void main() {
       final record = _makeRecord(
         entries: [_makeEntry(name: 'サーモン')],
       );
-      await tester.pumpWidget(_buildTestWidget(record));
+      await tester.pumpWidget(await _buildTestWidget(record));
 
       expect(find.text('サーモン'), findsOneWidget);
     });
@@ -73,7 +87,7 @@ void main() {
           _makeEntry(id: '3', name: '食品C'),
         ],
       );
-      await tester.pumpWidget(_buildTestWidget(record));
+      await tester.pumpWidget(await _buildTestWidget(record));
 
       expect(find.text('食品A'), findsOneWidget);
       expect(find.text('食品B'), findsOneWidget);
@@ -84,7 +98,7 @@ void main() {
       final record = _makeRecord(
         entries: [_makeEntry()],
       );
-      await tester.pumpWidget(_buildTestWidget(record));
+      await tester.pumpWidget(await _buildTestWidget(record));
 
       expect(find.byIcon(Icons.delete_outline), findsNothing);
     });
@@ -98,7 +112,7 @@ void main() {
           _makeEntry(id: '2', calories: 200, protein: 20),
         ],
       );
-      await tester.pumpWidget(_buildTestWidget(record));
+      await tester.pumpWidget(await _buildTestWidget(record));
 
       expect(find.textContaining('500'), findsOneWidget);
     });
@@ -110,9 +124,29 @@ void main() {
           _makeEntry(id: '2'),
         ],
       );
-      await tester.pumpWidget(_buildTestWidget(record));
+      await tester.pumpWidget(await _buildTestWidget(record));
 
       expect(find.textContaining('2 ${AppStrings.entryUnit}'), findsOneWidget);
+    });
+  });
+
+  group('DayDetailScreen - 食事追加FAB', () {
+    testWidgets('FABが表示される', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget(_makeRecord()));
+      await tester.pump();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('FABをタップするとボトムシートが開く', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget(_makeRecord()));
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextFormField, AppStrings.foodName),
+          findsOneWidget);
     });
   });
 }

--- a/test/screens/favorites_screen_test.dart
+++ b/test/screens/favorites_screen_test.dart
@@ -63,19 +63,17 @@ void main() {
     });
   });
 
-  group('FavoritesScreen - 追加操作', () {
-    testWidgets('タイルをタップするとスナックバーが表示される', (tester) async {
+  group('FavoritesScreen - 摂取量サマリー', () {
+    testWidgets('今日の摂取量ラベルが表示される', (tester) async {
       final provider = await _makeProvider();
-      await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
       await tester.pumpWidget(await _buildTestWidget(provider));
       await tester.pump();
 
-      await tester.tap(find.byType(ListTile));
-      await tester.pump();
-
-      expect(find.text('鶏むね肉 ${AppStrings.added}'), findsOneWidget);
+      expect(find.text(AppStrings.todayIntake), findsOneWidget);
     });
+  });
 
+  group('FavoritesScreen - 追加操作', () {
     testWidgets('タイルをタップしてもお気に入りリストは変わらない', (tester) async {
       final provider = await _makeProvider();
       await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);

--- a/test/screens/favorites_screen_test.dart
+++ b/test/screens/favorites_screen_test.dart
@@ -64,25 +64,25 @@ void main() {
   });
 
   group('FavoritesScreen - 追加操作', () {
-    testWidgets('追加ボタンをタップするとスナックバーが表示される', (tester) async {
+    testWidgets('タイルをタップするとスナックバーが表示される', (tester) async {
       final provider = await _makeProvider();
       await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
       await tester.pumpWidget(await _buildTestWidget(provider));
       await tester.pump();
 
-      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.tap(find.byType(ListTile));
       await tester.pump();
 
       expect(find.text('鶏むね肉 ${AppStrings.added}'), findsOneWidget);
     });
 
-    testWidgets('追加ボタンをタップしてもお気に入りリストは変わらない', (tester) async {
+    testWidgets('タイルをタップしてもお気に入りリストは変わらない', (tester) async {
       final provider = await _makeProvider();
       await provider.addFavorite(name: '鶏むね肉', calories: 150, protein: 30);
       await tester.pumpWidget(await _buildTestWidget(provider));
       await tester.pump();
 
-      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.tap(find.byType(ListTile));
       await tester.pump();
 
       expect(provider.favorites.length, 1);

--- a/test/widgets/favorite_entry_tile_test.dart
+++ b/test/widgets/favorite_entry_tile_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(find.textContaining(AppStrings.gramUnit), findsOneWidget);
     });
 
-    testWidgets('追加アイコンボタンが表示される', (tester) async {
+    testWidgets('タイルがタップ可能（onTapが設定されている）', (tester) async {
       await tester.pumpWidget(_buildTestWidget(
         FavoriteEntryTile(
           entry: _makeEntry(),
@@ -63,7 +63,7 @@ void main() {
           onDelete: () {},
         ),
       ));
-      expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+      expect(find.byType(ListTile), findsOneWidget);
     });
 
     testWidgets('削除アイコンボタンが表示される', (tester) async {
@@ -79,7 +79,7 @@ void main() {
   });
 
   group('FavoriteEntryTile - コールバック', () {
-    testWidgets('追加ボタンタップでonAddが呼ばれる', (tester) async {
+    testWidgets('タイルタップでonAddが呼ばれる', (tester) async {
       bool addCalled = false;
       await tester.pumpWidget(_buildTestWidget(
         FavoriteEntryTile(
@@ -88,7 +88,7 @@ void main() {
           onDelete: () {},
         ),
       ));
-      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.tap(find.byType(ListTile));
       await tester.pump();
       expect(addCalled, isTrue);
     });


### PR DESCRIPTION
## Summary

- 履歴画面から任意の日付に食事を追加できる機能を実装（`DietProvider.addEntryForDate()`）
- 日付選択時に SummaryCard + FoodEntryTile をインライン表示（詳細画面遷移を廃止）
- 履歴の食事追加フォームに ★ お気に入り登録ボタンを追加
- 今日の日付でエントリが空の場合も「この日の記録はありません」を表示するよう修正
- お気に入り画面にタップ全体で追加できるよう変更（+ ボタン廃止、タイル行全体がタップ領域）
- お気に入り画面上部に今日の摂取量サマリーバーを追加（kcal / g を常時表示）
- お気に入りタップ時のスナックバーを削除

## Test plan

- [x] `flutter test` が全テストパスすることを確認
- [x] 履歴タブでカレンダーから過去の日付を選択 → 「食事を追加」ボタン → フォーム入力 → カレンダーにマーカーが付く
- [x] 食事追加フォームで ★ をオンにして追加 → お気に入り画面に反映される
- [x] お気に入り画面上部に今日の摂取量（kcal / g）が表示される
- [x] お気に入りのタイル行全体をタップして食事が追加される

🤖 Generated with [Claude Code](https://claude.com/claude-code)