### PR TITLE
feat: 履歴の日別記録をシェアする機能

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -35,6 +35,7 @@ class AppStrings {
   static const String remainingCalorie = '残り';
   static const String notSet = '未設定';
   static const String noRecordForDay = 'この日の記録はありません';
+  static const String shareRecord = '記録をシェア';
   static const String calendarView = 'カレンダー';
   static const String listView = 'リスト';
 

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../constants/app_strings.dart';
@@ -375,16 +376,42 @@ class _HistoryScreenState extends State<HistoryScreen> {
         ),
         Padding(
           padding: const EdgeInsets.all(16),
-          child: SizedBox(
-            width: double.infinity,
-            child: FilledButton.tonal(
-              onPressed: () => _openAddEntrySheet(context, dateKey),
-              child: const Text(AppStrings.addFood),
-            ),
+          child: Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  onPressed: () => _openAddEntrySheet(context, dateKey),
+                  child: const Text(AppStrings.addFood),
+                ),
+              ),
+              if (record != null && record.entries.isNotEmpty) ...[
+                const SizedBox(width: 8),
+                IconButton.outlined(
+                  onPressed: () => _shareRecord(record, _selectedDay!),
+                  icon: const Icon(Icons.share),
+                  tooltip: AppStrings.shareRecord,
+                ),
+              ],
+            ],
           ),
         ),
       ],
     );
+  }
+
+  void _shareRecord(DailyRecord record, DateTime day) {
+    final formattedDate = DateFormat.yMMMEd('ja').format(day);
+    final buffer = StringBuffer();
+    buffer.writeln('📅 ${formattedDate}の食事記録');
+    buffer.writeln('🔥 合計カロリー: ${record.totalCalories.toStringAsFixed(0)} ${AppStrings.kcalUnit}');
+    buffer.writeln('💪 合計タンパク質: ${record.totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}');
+    buffer.writeln('📝 記録数: ${record.entryCount} ${AppStrings.entryUnit}');
+    buffer.writeln();
+    for (final entry in record.entries) {
+      buffer.writeln('🍽 ${entry.name}');
+      buffer.writeln('   ${entry.calories.toStringAsFixed(0)} ${AppStrings.kcalUnit} / ${entry.protein.toStringAsFixed(1)} ${AppStrings.gramUnit}');
+    }
+    Share.share(buffer.toString().trimRight());
   }
 
   void _openAddEntrySheet(BuildContext context, String dateKey) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -288,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -304,6 +320,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.15"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -368,6 +408,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -517,6 +573,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: "direct main"
     description:
@@ -549,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.10.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   table_calendar: ^3.1.0
   flutter_local_notifications: ^18.0.1
   timezone: ^0.9.4
+  share_plus: ^10.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- `share_plus` パッケージを追加し、OS ネイティブ共有シートを呼び出す
- 履歴画面で日付を選択し記録がある場合、「食事を追加」ボタンの右に共有アイコンボタンを表示
- タップすると LINE・メモ・メール等の任意のアプリへ送信できる
- シェアテキストのフォーマット例:
  ```
  📅 2024年1月15日（月）の食事記録
  🔥 合計カロリー: 500 kcal
  💪 合計タンパク質: 25.0 g
  📝 記録数: 2件

  🍽 鶏むね肉
     150 kcal / 30.0 g
  🍽 ご飯
     250 kcal / 4.0 g
  ```

## Test plan

- [x] `flutter test` が全テストパスすることを確認
- [x] 履歴画面で記録のある日付を選択 → シェアアイコンが表示される
- [x] シェアアイコンをタップ → OS 共有シートが開く
- [ ] LINE を選択して送信できる
- [x] 記録がない日付にはシェアアイコンが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)