### PR TITLE
feat: 朝・昼・晩 最大3回の食事リマインダー通知

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -44,6 +44,9 @@ class AppStrings {
   static const String notificationTime = '通知時刻';
   static const String notificationPermissionDenied =
       '通知の許可が必要です。設定アプリから通知を有効にしてください。';
+  static const String notificationMorning = '朝';
+  static const String notificationNoon = '昼';
+  static const String notificationEvening = '晩';
 
   // Favorites
   static const String todayIntake = '今日の摂取量';

--- a/lib/models/notification_slot.dart
+++ b/lib/models/notification_slot.dart
@@ -1,0 +1,19 @@
+class NotificationSlot {
+  final bool enabled;
+  final int hour;
+  final int minute;
+
+  const NotificationSlot({
+    required this.enabled,
+    required this.hour,
+    required this.minute,
+  });
+
+  NotificationSlot copyWith({bool? enabled, int? hour, int? minute}) {
+    return NotificationSlot(
+      enabled: enabled ?? this.enabled,
+      hour: hour ?? this.hour,
+      minute: minute ?? this.minute,
+    );
+  }
+}

--- a/lib/providers/diet_provider.dart
+++ b/lib/providers/diet_provider.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import '../models/daily_record.dart';
 import '../models/favorite_entry.dart';
 import '../models/food_entry.dart';
+import '../models/notification_slot.dart';
 import '../services/storage_service.dart';
 
 class DietProvider extends ChangeNotifier {
@@ -18,8 +19,11 @@ class DietProvider extends ChangeNotifier {
   bool _isLoading = true;
   double? _targetWeight;
   bool _notificationEnabled = false;
-  int _notificationHour = 20;
-  int _notificationMinute = 0;
+  List<NotificationSlot> _notificationSlots = const [
+    NotificationSlot(enabled: false, hour: 8, minute: 0),
+    NotificationSlot(enabled: false, hour: 12, minute: 0),
+    NotificationSlot(enabled: true, hour: 20, minute: 0),
+  ];
   List<FavoriteEntry> _favorites = [];
 
   DietProvider(this._storage);
@@ -31,8 +35,7 @@ class DietProvider extends ChangeNotifier {
   double? get calorieGoal =>
       _targetWeight != null ? _targetWeight! * 34 : null;
   bool get notificationEnabled => _notificationEnabled;
-  int get notificationHour => _notificationHour;
-  int get notificationMinute => _notificationMinute;
+  List<NotificationSlot> get notificationSlots => List.unmodifiable(_notificationSlots);
   List<FavoriteEntry> get favorites => List.unmodifiable(_favorites);
 
   static String _todayKey() {
@@ -45,8 +48,7 @@ class DietProvider extends ChangeNotifier {
     _allDates = _storage.getAllRecordDates();
     _targetWeight = _storage.loadTargetWeight();
     _notificationEnabled = _storage.loadNotificationEnabled();
-    _notificationHour = _storage.loadNotificationHour();
-    _notificationMinute = _storage.loadNotificationMinute();
+    _notificationSlots = _storage.loadNotificationSlots();
     _favorites = _storage.loadFavorites();
     final today = _storage.loadDailyRecord(_todayKey());
     if (today != null) {
@@ -145,17 +147,12 @@ class DietProvider extends ChangeNotifier {
 
   Future<void> saveNotificationSettings({
     required bool enabled,
-    required int hour,
-    required int minute,
+    required List<NotificationSlot> slots,
   }) async {
     _notificationEnabled = enabled;
-    _notificationHour = hour;
-    _notificationMinute = minute;
-    await _storage.saveNotificationSettings(
-      enabled: enabled,
-      hour: hour,
-      minute: minute,
-    );
+    _notificationSlots = slots;
+    await _storage.saveNotificationEnabled(enabled);
+    await _storage.saveNotificationSlots(slots);
     notifyListeners();
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../constants/app_strings.dart';
+import '../models/notification_slot.dart';
 import '../providers/diet_provider.dart';
 import '../services/notification_service.dart';
 
@@ -18,7 +19,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final _notificationService = NotificationService();
   double? _previewGoal;
   bool _notificationEnabled = false;
-  TimeOfDay _notificationTime = const TimeOfDay(hour: 20, minute: 0);
+  List<NotificationSlot> _slots = const [
+    NotificationSlot(enabled: false, hour: 8, minute: 0),
+    NotificationSlot(enabled: false, hour: 12, minute: 0),
+    NotificationSlot(enabled: true, hour: 20, minute: 0),
+  ];
 
   @override
   void initState() {
@@ -35,8 +40,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _loadNotificationSettings(DietProvider provider) {
     setState(() {
       _notificationEnabled = provider.notificationEnabled;
-      _notificationTime =
-          TimeOfDay(hour: provider.notificationHour, minute: provider.notificationMinute);
+      _slots = List.of(provider.notificationSlots);
     });
   }
 
@@ -67,40 +71,51 @@ class _SettingsScreenState extends State<SettingsScreen> {
         );
         return;
       }
-      await _notificationService.scheduleDaily(
-        hour: _notificationTime.hour,
-        minute: _notificationTime.minute,
-      );
+      await _notificationService.scheduleSlots(_slots);
     } else {
-      await _notificationService.cancel();
+      await _notificationService.cancelAll();
     }
     if (!mounted) return;
     await context.read<DietProvider>().saveNotificationSettings(
           enabled: enabled,
-          hour: _notificationTime.hour,
-          minute: _notificationTime.minute,
+          slots: _slots,
         );
     setState(() => _notificationEnabled = enabled);
   }
 
-  Future<void> _pickTime() async {
+  Future<void> _toggleSlot(int index, bool enabled) async {
+    final updated = List.of(_slots);
+    updated[index] = updated[index].copyWith(enabled: enabled);
+    setState(() => _slots = updated);
+    if (_notificationEnabled) {
+      await _notificationService.scheduleSlots(updated);
+    }
+    await context.read<DietProvider>().saveNotificationSettings(
+          enabled: _notificationEnabled,
+          slots: updated,
+        );
+  }
+
+  Future<void> _pickTime(int index) async {
+    final current = _slots[index];
     final picked = await showTimePicker(
       context: context,
-      initialTime: _notificationTime,
+      initialTime: TimeOfDay(hour: current.hour, minute: current.minute),
     );
     if (picked == null || !mounted) return;
-    setState(() => _notificationTime = picked);
+    final updated = List.of(_slots);
+    updated[index] = updated[index].copyWith(
+      hour: picked.hour,
+      minute: picked.minute,
+    );
+    setState(() => _slots = updated);
     if (_notificationEnabled) {
-      await _notificationService.scheduleDaily(
-        hour: picked.hour,
-        minute: picked.minute,
-      );
-      await context.read<DietProvider>().saveNotificationSettings(
-            enabled: true,
-            hour: picked.hour,
-            minute: picked.minute,
-          );
+      await _notificationService.scheduleSlots(updated);
     }
+    await context.read<DietProvider>().saveNotificationSettings(
+          enabled: _notificationEnabled,
+          slots: updated,
+        );
   }
 
   @override
@@ -200,18 +215,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         ),
                         if (_notificationEnabled) ...[
                           const Divider(height: 1),
-                          ListTile(
-                            leading: const Icon(Icons.access_time),
-                            title: const Text(AppStrings.notificationTime),
-                            trailing: Text(
-                              _notificationTime.format(context),
-                              style: theme.textTheme.bodyLarge?.copyWith(
-                                color: theme.colorScheme.primary,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            onTap: _pickTime,
-                          ),
+                          _buildSlotTile(context, theme, 0, AppStrings.notificationMorning),
+                          const Divider(height: 1, indent: 16, endIndent: 16),
+                          _buildSlotTile(context, theme, 1, AppStrings.notificationNoon),
+                          const Divider(height: 1, indent: 16, endIndent: 16),
+                          _buildSlotTile(context, theme, 2, AppStrings.notificationEvening),
                         ],
                       ],
                     ),
@@ -222,6 +230,45 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildSlotTile(
+      BuildContext context, ThemeData theme, int index, String label) {
+    final slot = _slots[index];
+    final timeLabel = TimeOfDay(hour: slot.hour, minute: slot.minute)
+        .format(context);
+    return ListTile(
+      leading: SizedBox(
+        width: 32,
+        child: Text(
+          label,
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+      ),
+      title: slot.enabled
+          ? GestureDetector(
+              onTap: () => _pickTime(index),
+              child: Text(
+                timeLabel,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            )
+          : Text(
+              timeLabel,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+      trailing: Switch(
+        value: slot.enabled,
+        onChanged: (v) => _toggleSlot(index, v),
+      ),
+      onTap: slot.enabled ? () => _pickTime(index) : null,
     );
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -2,8 +2,11 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
+import '../models/notification_slot.dart';
+
 class NotificationService {
-  static const int _reminderId = 1;
+  // 朝=1, 昼=2, 晩=3
+  static const List<int> _slotIds = [1, 2, 3];
   static const String _channelId = 'diet_reminder';
 
   final FlutterLocalNotificationsPlugin _plugin =
@@ -33,16 +36,38 @@ class NotificationService {
     return granted ?? false;
   }
 
-  Future<void> scheduleDaily({required int hour, required int minute}) async {
-    await _plugin.cancel(_reminderId);
+  /// 有効なスロット（最大3件）をスケジュールする。
+  /// まず既存の全通知をキャンセルしてから再スケジュール。
+  Future<void> scheduleSlots(List<NotificationSlot> slots) async {
+    await cancelAll();
+    for (int i = 0; i < slots.length && i < _slotIds.length; i++) {
+      if (!slots[i].enabled) continue;
+      await _scheduleOne(
+        id: _slotIds[i],
+        hour: slots[i].hour,
+        minute: slots[i].minute,
+      );
+    }
+  }
 
+  Future<void> cancelAll() async {
+    for (final id in _slotIds) {
+      await _plugin.cancel(id);
+    }
+  }
+
+  Future<void> _scheduleOne({
+    required int id,
+    required int hour,
+    required int minute,
+  }) async {
     const iosDetails = DarwinNotificationDetails(
       categoryIdentifier: _channelId,
     );
     const details = NotificationDetails(iOS: iosDetails);
 
     await _plugin.zonedSchedule(
-      _reminderId,
+      id,
       '🍽 食事を記録しましょう',
       '今日の食事をカロリー記録アプリに入力してください',
       _nextInstanceOfTime(hour, minute),
@@ -52,10 +77,6 @@ class NotificationService {
           UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,
     );
-  }
-
-  Future<void> cancel() async {
-    await _plugin.cancel(_reminderId);
   }
 
   static tz.TZDateTime _nextInstanceOfTime(int hour, int minute) {

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/daily_record.dart';
 import '../models/favorite_entry.dart';
+import '../models/notification_slot.dart';
 
 class StorageService {
   static const String _prefix = 'diet_';
@@ -11,8 +12,15 @@ class StorageService {
   static const String _targetWeightKey = 'diet_target_weight';
   static const String _firstLaunchKey = 'diet_first_launch_done';
   static const String _notificationEnabledKey = 'diet_notification_enabled';
+  // 旧キー（後方互換のため読み取りのみ使用）
   static const String _notificationHourKey = 'diet_notification_hour';
   static const String _notificationMinuteKey = 'diet_notification_minute';
+  // スロットキー
+  static const _slotKeys = [
+    ('diet_notification_morning', 8, 0),   // 朝: デフォルト08:00 OFF
+    ('diet_notification_noon', 12, 0),     // 昼: デフォルト12:00 OFF
+    ('diet_notification_evening', 20, 0),  // 晩: デフォルト20:00 ON
+  ];
   static const String _favoritesKey = 'diet_favorites';
 
   late SharedPreferences _prefs;
@@ -65,22 +73,35 @@ class StorageService {
     return _prefs.getBool(_notificationEnabledKey) ?? false;
   }
 
-  int loadNotificationHour() {
-    return _prefs.getInt(_notificationHourKey) ?? 20;
-  }
-
-  int loadNotificationMinute() {
-    return _prefs.getInt(_notificationMinuteKey) ?? 0;
-  }
-
-  Future<void> saveNotificationSettings({
-    required bool enabled,
-    required int hour,
-    required int minute,
-  }) async {
+  Future<void> saveNotificationEnabled(bool enabled) async {
     await _prefs.setBool(_notificationEnabledKey, enabled);
-    await _prefs.setInt(_notificationHourKey, hour);
-    await _prefs.setInt(_notificationMinuteKey, minute);
+  }
+
+  /// 3スロット（朝・昼・晩）を読み込む。
+  /// 晩スロットは旧設定キーが存在すれば時刻を引き継ぐ。
+  List<NotificationSlot> loadNotificationSlots() {
+    final slots = <NotificationSlot>[];
+    for (int i = 0; i < _slotKeys.length; i++) {
+      final (prefix, defaultHour, defaultMinute) = _slotKeys[i];
+      // 晩スロット（index=2）は旧設定から時刻を引き継ぐ
+      final legacyHour = i == 2 ? (_prefs.getInt(_notificationHourKey) ?? defaultHour) : defaultHour;
+      final legacyMinute = i == 2 ? (_prefs.getInt(_notificationMinuteKey) ?? defaultMinute) : defaultMinute;
+      slots.add(NotificationSlot(
+        enabled: _prefs.getBool('${prefix}_enabled') ?? (i == 2),
+        hour: _prefs.getInt('${prefix}_hour') ?? legacyHour,
+        minute: _prefs.getInt('${prefix}_minute') ?? legacyMinute,
+      ));
+    }
+    return slots;
+  }
+
+  Future<void> saveNotificationSlots(List<NotificationSlot> slots) async {
+    for (int i = 0; i < slots.length && i < _slotKeys.length; i++) {
+      final (prefix, _, __) = _slotKeys[i];
+      await _prefs.setBool('${prefix}_enabled', slots[i].enabled);
+      await _prefs.setInt('${prefix}_hour', slots[i].hour);
+      await _prefs.setInt('${prefix}_minute', slots[i].minute);
+    }
   }
 
   Future<void> saveFavorites(List<FavoriteEntry> favorites) async {

--- a/test/providers/diet_provider_test.dart
+++ b/test/providers/diet_provider_test.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:diet_app/models/daily_record.dart';
 import 'package:diet_app/providers/diet_provider.dart';
 import 'package:diet_app/services/storage_service.dart';
+// ignore: unused_import
+import 'package:diet_app/models/notification_slot.dart';
 
 void main() {
   late StorageService storage;
@@ -35,6 +37,16 @@ void main() {
 
     test('初期状態では全日付リストが空', () {
       expect(provider.allDates, isEmpty);
+    });
+
+    test('初期状態では通知スロットが3件', () {
+      expect(provider.notificationSlots.length, 3);
+    });
+
+    test('初期状態では朝・昼スロットがOFF、晩スロットがON', () {
+      expect(provider.notificationSlots[0].enabled, isFalse); // 朝
+      expect(provider.notificationSlots[1].enabled, isFalse); // 昼
+      expect(provider.notificationSlots[2].enabled, isTrue);  // 晩
     });
   });
 

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -104,6 +104,36 @@ void main() {
     });
   });
 
+  group('SettingsScreen - 通知スロット', () {
+    testWidgets('通知ONで朝・昼・晩のラベルが表示される', (tester) async {
+      final values = <String, Object>{
+        'diet_notification_enabled': true,
+      };
+      SharedPreferences.setMockInitialValues(values);
+      final storage = StorageService();
+      final provider = DietProvider(storage);
+      await provider.init();
+      await tester.pumpWidget(ChangeNotifierProvider<DietProvider>.value(
+        value: provider,
+        child: const MaterialApp(home: SettingsScreen()),
+      ));
+      await tester.pump();
+
+      expect(find.text(AppStrings.notificationMorning), findsOneWidget);
+      expect(find.text(AppStrings.notificationNoon), findsOneWidget);
+      expect(find.text(AppStrings.notificationEvening), findsOneWidget);
+    });
+
+    testWidgets('通知OFFでは朝・昼・晩のラベルが表示されない', (tester) async {
+      await tester.pumpWidget(await _buildTestWidget());
+      await tester.pump();
+
+      expect(find.text(AppStrings.notificationMorning), findsNothing);
+      expect(find.text(AppStrings.notificationNoon), findsNothing);
+      expect(find.text(AppStrings.notificationEvening), findsNothing);
+    });
+  });
+
   group('SettingsScreen - 保存', () {
     testWidgets('正しい値を入力して保存すると保存完了スナックバーが表示される', (tester) async {
       await tester.pumpWidget(await _buildTestWidget());


### PR DESCRIPTION
## Summary

- 通知を1日1回から最大3回（朝・昼・晩）に拡張
- メインスイッチON時に3スロット行が表示され、各スロットを個別にON/OFF可能
- 時刻をタップするとピッカーで変更できる
- デフォルト設定: 朝OFF(08:00)・昼OFF(12:00)・晩ON(20:00)
- 旧設定（単一通知時刻）は晩スロットに自動引き継ぎ

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/models/notification_slot.dart` | 新規: スロットモデル（enabled/hour/minute）|
| `lib/services/notification_service.dart` | `scheduleSlots()` / `cancelAll()` に刷新 |
| `lib/services/storage_service.dart` | スロット用9キー追加・後方互換読み取り |
| `lib/providers/diet_provider.dart` | `notificationSlots` ゲッター追加 |
| `lib/screens/settings_screen.dart` | 朝・昼・晩3行UI実装 |
| `lib/constants/app_strings.dart` | 朝・昼・晩文字列追加 |

## Test plan

- [ ] `flutter test` 全148テストパス
- [ ] 設定画面 → 通知ON → 朝・昼・晩の3行が表示される
- [ ] 各スロットのトグルで個別ON/OFFできる
- [ ] 時刻タップで時刻ピッカーが開く
- [ ] アプリ再起動後も設定が保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)