### PR TITLE
fix: Codemagic メール通知先を修正

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -49,7 +49,7 @@ workflows:
         submit_to_testflight: true
       email:
         recipients:
-          - $CM_BUILD_REPORTER_EMAIL
+          - register01010@gmail.com
         notify:
           success: true
           failure: true


### PR DESCRIPTION
## Summary

- `$CM_BUILD_REPORTER_EMAIL` 環境変数が未設定によるバリデーションエラーを修正
- メールアドレスを直接指定する形に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)