### PR TITLE
fix: ios_signingの不正なフィールドを削除

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -36,15 +36,12 @@ workflows:
         script: |
           xcode-project use-profiles
           flutter build ipa --release \
+            --build-number=$BUILD_NUMBER \
             --export-options-plist=/Users/builder/export_options.plist
 
       - name: TestFlight へアップロード
         script: |
           printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
-          echo "--- authkey.p8 first line ---"
-          head -1 /tmp/authkey.p8
-          echo "--- authkey.p8 size ---"
-          wc -c /tmp/authkey.p8
           app-store-connect publish \
             --path "$(find build/ios/ipa -name '*.ipa' | head -1)" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,7 +40,9 @@ workflows:
 
       - name: TestFlight へアップロード
         script: |
-          echo "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
+          # base64デコードを試み、失敗したらそのまま使用
+          echo "$APP_STORE_CONNECT_PRIVATE_KEY" | base64 -d > /tmp/authkey.p8 2>/dev/null \
+            || echo "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
           app-store-connect publish \
             --path "$(find build/ios/ipa -name '*.ipa' | head -1)" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,11 +40,12 @@ workflows:
 
       - name: TestFlight へアップロード
         script: |
+          echo "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
           app-store-connect publish \
             --path "$(find build/ios/ipa -name '*.ipa' | head -1)" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
             --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-            --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
+            --private-key @file:/tmp/authkey.p8 \
             --testflight
 
     artifacts:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -34,25 +34,7 @@ workflows:
 
       - name: iOS ビルド (IPA)
         script: |
-          cat > /Users/builder/export_options.plist << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>app-store</string>
-            <key>teamID</key>
-            <string>785YQ4QVC3</string>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>jp.nanairo.calorierecord</key>
-              <string>diet_app_appstore</string>
-            </dict>
-          </dict>
-          </plist>
-          EOF
+          xcode-project use-profiles
           flutter build ipa --release \
             --export-options-plist=/Users/builder/export_options.plist
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,9 +40,11 @@ workflows:
 
       - name: TestFlight へアップロード
         script: |
-          # base64デコードを試み、失敗したらそのまま使用
-          echo "$APP_STORE_CONNECT_PRIVATE_KEY" | base64 -d > /tmp/authkey.p8 2>/dev/null \
-            || echo "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > /tmp/authkey.p8
+          echo "--- authkey.p8 first line ---"
+          head -1 /tmp/authkey.p8
+          echo "--- authkey.p8 size ---"
+          wc -c /tmp/authkey.p8
           app-store-connect publish \
             --path "$(find build/ios/ipa -name '*.ipa' | head -1)" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,16 +38,20 @@ workflows:
           flutter build ipa --release \
             --export-options-plist=/Users/builder/export_options.plist
 
+      - name: TestFlight へアップロード
+        script: |
+          app-store-connect publish \
+            --path "$(find build/ios/ipa -name '*.ipa' | head -1)" \
+            --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+            --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
+            --testflight
+
     artifacts:
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
 
     publishing:
-      app_store_connect:
-        api_key: $APP_STORE_CONNECT_PRIVATE_KEY
-        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
-        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
-        submit_to_testflight: true
       email:
         recipients:
           - register01010@gmail.com

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -11,8 +11,6 @@ workflows:
       ios_signing:
         distribution_type: app_store
         bundle_identifier: jp.nanairo.calorierecord
-        certificate: diet_app_distribution
-        provisioning_profile: diet_app_appstore
       vars:
         BUNDLE_ID: jp.nanairo.calorierecord
         XCODE_PROJECT: ios/Runner.xcodeproj

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -34,6 +34,25 @@ workflows:
 
       - name: iOS ビルド (IPA)
         script: |
+          cat > /Users/builder/export_options.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>785YQ4QVC3</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>jp.nanairo.calorierecord</key>
+              <string>diet_app_appstore</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
           flutter build ipa --release \
             --export-options-plist=/Users/builder/export_options.plist
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 785YQ4QVC3;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.nanairo.calorierecord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -547,6 +548,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 785YQ4QVC3;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.nanairo.calorierecord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -569,6 +571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				DEVELOPMENT_TEAM = 785YQ4QVC3;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.nanairo.calorierecord;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: diet_app
 description: "毎日の食事（カロリー・タンパク質）を記録するiOSアプリ"
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: diet_app
 description: "毎日の食事（カロリー・タンパク質）を記録するiOSアプリ"
 publish_to: 'none'
-version: 1.0.0+2
+version: 1.0.0+3
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
## Summary

- `ios_signing` ブロックに追加した `certificate` / `provisioning_profile` フィールドが Codemagic の YAML バリデーションエラーになったため削除
- Codemagic Settings に登録済みの `diet_app_distribution`（証明書）・`diet_app_appstore`（プロファイル）は自動的に参照される

🤖 Generated with [Claude Code](https://claude.com/claude-code)