### PR TITLE
fix: ホーム画面のアプリ名を「カロタン」に統一 (#29)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>
-		<string>カロリー記録</string>
+		<string>カロタン</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundleName</key>
-		<string>カロリー記録</string>
+		<string>カロタン</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## 対応 Issue

Closes #29

## 原因

`ios/Runner/Info.plist` の以下2つのフィールドが「カロリー記録」のままになっており、App Store の表示名「カロタン」と不一致が生じていた。

| フィールド | 役割 | 修正前 | 修正後 |
|---|---|---|---|
| `CFBundleDisplayName` | ホーム画面アイコン下の表示名 | カロリー記録 | **カロタン** |
| `CFBundleName` | システム内部のアプリ名 | カロリー記録 | **カロタン** |

## 変更ファイル

- `ios/Runner/Info.plist`

## 確認方法

ビルドしてデバイスにインストールすると、ホーム画面のアイコン下が「カロタン」になることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)