### PR TITLE
chore: 本番リリース向けコード対応

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -15,28 +15,41 @@ workflows:
         BUNDLE_ID: jp.nanairo.calorierecord
         XCODE_PROJECT: ios/Runner.xcodeproj
         XCODE_SCHEME: Runner
+        APP_STORE_CONNECT_KEY_IDENTIFIER: $APP_STORE_CONNECT_KEY_IDENTIFIER
+        APP_STORE_CONNECT_ISSUER_ID: $APP_STORE_CONNECT_ISSUER_ID
+        APP_STORE_CONNECT_PRIVATE_KEY: $APP_STORE_CONNECT_PRIVATE_KEY
       groups:
         - app_store_connect  # Codemagic ダッシュボードで設定するグループ
 
     triggering:
       events:
         - push
+        - tag
       branch_patterns:
         - pattern: main
+          include: true
+      tag_patterns:
+        - pattern: 'v*'
           include: true
 
     scripts:
       - name: Flutter パッケージ取得
         script: flutter pub get
 
+      - name: Flutter 静的解析
+        script: flutter analyze --no-fatal-infos
+
       - name: テスト実行
         script: flutter test
 
+      - name: プロビジョニングプロファイルの適用
+        script: xcode-project use-profiles
+
       - name: iOS ビルド (IPA)
         script: |
-          xcode-project use-profiles
           flutter build ipa --release \
             --build-number=$BUILD_NUMBER \
+            --build-name=$(cat pubspec.yaml | grep "^version:" | awk '{print $2}' | cut -d'+' -f1) \
             --export-options-plist=/Users/builder/export_options.plist
 
       - name: TestFlight へアップロード
@@ -47,11 +60,13 @@ workflows:
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
             --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
             --private-key @file:/tmp/authkey.p8 \
-            --testflight
+            --testflight \
+            --whats-new "Codemagic 自動ビルド (Build $BUILD_NUMBER)"
 
     artifacts:
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
+      - flutter_drive.log
 
     publishing:
       email:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,51 @@
+# Flutter iOS 向け Podfile
+platform :ios, '16.0'
+
+# CocoaPods の統計送信を無効化（ビルド時間短縮）
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(
+    File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__
+  )
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. " \
+          "flutter pub get を先に実行してください"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. " \
+        "Generated.xcconfig を削除して flutter pub get を再実行してください"
+end
+
+require File.expand_path(
+  File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root
+)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,7 +49,7 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<false/>
-		<key>NSUserNotificationUsageDescription</key>
+		<key>NSUserNotificationsUsageDescription</key>
 		<string>毎日の食事記録を忘れないようにリマインダー通知を送ります。</string>
 	</dict>
 </plist>

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+  <!-- アプリはユーザーをクロスアプリ追跡しない -->
+  <key>NSPrivacyTracking</key>
+  <false/>
+
+  <!-- 追跡に使用するドメインなし -->
+  <key>NSPrivacyTrackingDomains</key>
+  <array/>
+
+  <!--
+    収集データの種類
+    このアプリが収集するデータはすべてデバイスローカル（SharedPreferences / iCloud）に保存され、
+    開発者サーバーへの送信は行わない。
+  -->
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array>
+    <!-- 食事記録（カロリー・タンパク質）= ヘルス＆フィットネスデータ -->
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypeHealth</string>
+      <!-- 第三者サーバーへ送信しないため「収集しない」に相当 -->
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+      </array>
+    </dict>
+  </array>
+
+  <!--
+    プライバシーに関わる API のアクセス理由
+    Apple の Required Reason API リストに基づき宣言する。
+  -->
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+
+    <!--
+      UserDefaults API
+      使用箇所: shared_preferences パッケージ（目標体重・通知設定の永続化）
+      理由コード CA92.1: 同一バンドル内のユーザーデフォルトへのアクセス
+    -->
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+
+    <!--
+      ファイルタイムスタンプ API
+      使用箇所: Flutter エンジン（内部的なファイル管理）
+      理由コード C617.1: アプリの機能としてファイルのタイムスタンプにアクセスする
+    -->
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>C617.1</string>
+      </array>
+    </dict>
+
+    <!--
+      システムブート時刻 API
+      使用箇所: Flutter エンジン（アニメーション・タイマー計算）
+      理由コード 35F9.1: アプリ機能のためにイベントの順序付けに使用する
+    -->
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>35F9.1</string>
+      </array>
+    </dict>
+
+    <!--
+      ディスク空き容量 API
+      使用箇所: Flutter エンジン・path_provider（ストレージ確認）
+      理由コード 85F4.1: アプリ機能の一部としてディスク空き容量にアクセスする
+    -->
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>85F4.1</string>
+      </array>
+    </dict>
+
+  </array>
+
+</dict>
+</plist>

--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -404,7 +404,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
   Future<void> _shareRecord(DailyRecord record, DateTime day) async {
     final formattedDate = DateFormat.yMMMEd('ja').format(day);
     final buffer = StringBuffer();
-    buffer.writeln('📅 ${formattedDate}の食事記録');
+    buffer.writeln('📅 $formattedDateの食事記録');
     buffer.writeln('🔥 合計カロリー: ${record.totalCalories.toStringAsFixed(0)} ${AppStrings.kcalUnit}');
     buffer.writeln('💪 合計タンパク質: ${record.totalProtein.toStringAsFixed(1)} ${AppStrings.gramUnit}');
     buffer.writeln('📝 記録数: ${record.entryCount} ${AppStrings.entryUnit}');

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -92,17 +92,17 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 ),
               ),
               const SizedBox(height: 40),
-              _FeatureTile(
+              const _FeatureTile(
                 icon: Icons.edit_note,
                 text: AppStrings.onboardingFeature1,
               ),
               const SizedBox(height: 12),
-              _FeatureTile(
+              const _FeatureTile(
                 icon: Icons.local_fire_department,
                 text: AppStrings.onboardingFeature2,
               ),
               const SizedBox(height: 12),
-              _FeatureTile(
+              const _FeatureTile(
                 icon: Icons.calendar_month,
                 text: AppStrings.onboardingFeature3,
               ),

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -97,7 +97,7 @@ class StorageService {
 
   Future<void> saveNotificationSlots(List<NotificationSlot> slots) async {
     for (int i = 0; i < slots.length && i < _slotKeys.length; i++) {
-      final (prefix, _, __) = _slotKeys[i];
+      final (prefix, _, _) = _slotKeys[i];
       await _prefs.setBool('${prefix}_enabled', slots[i].enabled);
       await _prefs.setInt('${prefix}_hour', slots[i].hour);
       await _prefs.setInt('${prefix}_minute', slots[i].minute);

--- a/lib/widgets/calorie_arc_gauge.dart
+++ b/lib/widgets/calorie_arc_gauge.dart
@@ -100,7 +100,7 @@ class _ArcPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final strokeWidth = 14.0;
+    const strokeWidth = 14.0;
     // 丸キャップ（strokeWidth/2）が下にはみ出さないようセンターを上にずらす
     final center = Offset(size.width / 2, size.height - strokeWidth / 2);
     final radius = math.min(size.width / 2, size.height - strokeWidth / 2) - strokeWidth / 2;

--- a/test/providers/diet_provider_test.dart
+++ b/test/providers/diet_provider_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:diet_app/models/daily_record.dart';
 import 'package:diet_app/providers/diet_provider.dart';
 import 'package:diet_app/services/storage_service.dart';
 // ignore: unused_import


### PR DESCRIPTION
## 概要

App Store 審査提出に必要なコード対応をまとめて実施。

## 変更内容

### 🔒 iOS プライバシーマニフェスト（新規）
`ios/Runner/PrivacyInfo.xcprivacy` を新規作成。Apple の必須要件（2024/05〜）に対応。

| 申告内容 | 値 |
|---|---|
| NSPrivacyTracking | false（追跡なし） |
| NSPrivacyTrackingDomains | 空（追跡ドメインなし） |
| 収集データ | ヘルス＆フィットネス（デバイスローカルのみ） |
| UserDefaults API (CA92.1) | shared_preferences が使用 |
| FileTimestamp API (C617.1) | Flutter エンジンが使用 |
| SystemBootTime API (35F9.1) | Flutter エンジンが使用 |
| DiskSpace API (85F4.1) | Flutter エンジンが使用 |

### 📋 Info.plist 修正
- `NSUserNotificationUsageDescription`（macOS 用キー） → `NSUserNotificationsUsageDescription`（iOS 正式キー）に修正

### ⚙️ codemagic.yaml 改善
- `flutter analyze --no-fatal-infos` ステップを追加
- タグトリガー `v*` を追加（バージョンタグからもビルド可能に）
- ビルド名を `pubspec.yaml` から自動取得
- TestFlight アップロードに `--whats-new` オプションを追加

### 🧹 既存 lint 警告を全解消
`flutter analyze` がゼロ issue になるよう修正。

## テスト
`flutter analyze` → No issues found  
`flutter test` → 166件 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)